### PR TITLE
feat: 모든 브랜치에 main 머지 명령어 추가

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -55,6 +55,14 @@ When user types "pl" or "풀", automatically execute:
 3. Main branches pull: Update `main`, `develop` (checkout → pull → return)
 4. Summary: Provide updated branches and changes summary
 
+## Merge Main to All Branches ("merge-main" or "mg" command)
+
+When user types "merge-main" or "mg", automatically execute:
+
+1. Save current branch → update `main` → get all local branches (excluding `main`)
+2. For each branch: checkout → `git merge main --no-edit` → skip if conflicts
+3. Return to original branch → provide summary
+
 ## Code Style & Patterns
 
 ### Frontend (React + TypeScript)


### PR DESCRIPTION
- 'mg' 또는 'merge-main' 명령어로 모든 로컬 브랜치에 main 머지
- 현재 브랜치 저장 → main 업데이트 → 각 브랜치에 머지 → 원래 브랜치 복귀
- 충돌 발생 시 해당 브랜치 건너뛰고 계속 진행