### PR TITLE
[#33] 태그 상세 화면 및 팔로우 기능 구현

### DIFF
--- a/.cursor/rules/workflow/git.md
+++ b/.cursor/rules/workflow/git.md
@@ -15,6 +15,16 @@
   - Do not create temporary markdown files for issue preparation - create issues directly
   - If temporary markdown files are created, delete them immediately after creating the issue
 
+## 신규 기능 브랜치 워크플로우
+
+이슈 기반 신규 기능 구현 시 반드시 다음 순서를 따른다:
+
+1. 신규 브랜치 생성: `git checkout -b feature/issue-{번호}-{설명}`
+2. 기능 구현 (plan 확인 후 실행)
+3. 빌드/린트/타입체크 통과 확인: `npm run build`, `tsc --noEmit`
+4. 커밋 후 원격 브랜치 push: `git push -u origin HEAD`
+5. `gh pr create`로 PR 생성 — 반드시 `Closes #{번호}` 포함
+
 ## DB Migration Commits
 
 - When committing entity file changes (`*.entity.ts`), always include Migration files (`migrations/*.ts`)

--- a/backend/migrations/1786000000000-CreateTagFollowsTable.ts
+++ b/backend/migrations/1786000000000-CreateTagFollowsTable.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTagFollowsTable1786000000000 implements MigrationInterface {
+  name = 'CreateTagFollowsTable1786000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS \`tag_follows\` (
+        \`id\` INT AUTO_INCREMENT PRIMARY KEY,
+        \`userId\` INT NOT NULL,
+        \`tagId\` INT NOT NULL,
+        \`createdAt\` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY \`unique_user_tag_follow\` (\`userId\`, \`tagId\`),
+        INDEX \`IDX_tag_follows_userId\` (\`userId\`),
+        INDEX \`IDX_tag_follows_tagId\` (\`tagId\`),
+        FOREIGN KEY (\`userId\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE,
+        FOREIGN KEY (\`tagId\`) REFERENCES \`tags\`(\`id\`) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS \`tag_follows\``);
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { CellarModule } from './cellar/cellar.module';
 import { PostsModule } from './posts/posts.module';
 import { CommentsModule } from './comments/comments.module';
 import { ReportsModule } from './reports/reports.module';
+import { TagsModule } from './tags/tags.module';
 import { getTypeOrmConfig } from './database/typeorm.config';
 import { HealthController } from './health/health.controller';
 import { User } from './users/entities/user.entity';
@@ -50,6 +51,7 @@ import { HttpExceptionFilter } from './common/http-exception.filter';
     PostsModule,
     CommentsModule,
     ReportsModule,
+    TagsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/notes/entities/tag-follow.entity.ts
+++ b/backend/src/notes/entities/tag-follow.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, CreateDateColumn, Unique, Index } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Tag } from './tag.entity';
+
+@Entity('tag_follows')
+@Unique(['userId', 'tagId'])
+@Index(['userId'])
+@Index(['tagId'])
+export class TagFollow {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  tagId: number;
+
+  @ManyToOne(() => Tag, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'tagId' })
+  tag: Tag;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/tags/dto/tag-detail.dto.ts
+++ b/backend/src/tags/dto/tag-detail.dto.ts
@@ -1,0 +1,37 @@
+export class TagDetailDto {
+  name: string;
+  noteCount: number;
+  isFollowing: boolean;
+  followerCount: number;
+}
+
+export class TagNoteDto {
+  id: number;
+  teaId: number;
+  teaName: string;
+  teaImageUrl: string | null;
+  userId: number;
+  userName: string;
+  userProfileImageUrl: string | null;
+  overallRating: number | null;
+  memo: string | null;
+  tags: string[];
+  likeCount: number;
+  isLiked: boolean;
+  isBookmarked: boolean;
+  createdAt: Date;
+}
+
+export class TagNoteListDto {
+  tag: TagDetailDto;
+  notes: TagNoteDto[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export class PopularTagDto {
+  name: string;
+  noteCount: number;
+  isFollowing?: boolean;
+}

--- a/backend/src/tags/tags.controller.ts
+++ b/backend/src/tags/tags.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Query,
+  Request,
+  UseGuards,
+  ParseIntPipe,
+  DefaultValuePipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt.guard';
+import { TagsService } from './tags.service';
+
+@Controller('tags')
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+
+  @UseGuards(OptionalJwtAuthGuard)
+  @Get('popular')
+  async getPopularTags(
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Request() req,
+  ) {
+    const currentUserId = req.user?.userId;
+    return this.tagsService.getPopularTags(limit, currentUserId);
+  }
+
+  @UseGuards(OptionalJwtAuthGuard)
+  @Get('recent')
+  async getRecentTags(
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Request() req,
+  ) {
+    const currentUserId = req.user?.userId;
+    return this.tagsService.getRecentTags(limit, currentUserId);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Get('followed')
+  async getFollowedTags(@Request() req) {
+    return this.tagsService.getFollowedTags(req.user.userId);
+  }
+
+  @UseGuards(OptionalJwtAuthGuard)
+  @Get(':name')
+  async getTagDetail(@Param('name') name: string, @Request() req) {
+    const currentUserId = req.user?.userId;
+    return this.tagsService.getTagDetail(name, currentUserId);
+  }
+
+  @UseGuards(OptionalJwtAuthGuard)
+  @Get(':name/notes')
+  async getNotesByTag(
+    @Param('name') name: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+    @Request() req,
+  ) {
+    const currentUserId = req.user?.userId;
+    return this.tagsService.getNotesByTag(name, page, limit, currentUserId);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Post(':name/follow')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async followTag(@Param('name') name: string, @Request() req) {
+    await this.tagsService.followTag(req.user.userId, name);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Delete(':name/follow')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async unfollowTag(@Param('name') name: string, @Request() req) {
+    await this.tagsService.unfollowTag(req.user.userId, name);
+  }
+}

--- a/backend/src/tags/tags.module.ts
+++ b/backend/src/tags/tags.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TagsService } from './tags.service';
+import { TagsController } from './tags.controller';
+import { Tag } from '../notes/entities/tag.entity';
+import { NoteTag } from '../notes/entities/note-tag.entity';
+import { Note } from '../notes/entities/note.entity';
+import { NoteLike } from '../notes/entities/note-like.entity';
+import { NoteBookmark } from '../notes/entities/note-bookmark.entity';
+import { TagFollow } from '../notes/entities/tag-follow.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Tag, NoteTag, Note, NoteLike, NoteBookmark, TagFollow]),
+  ],
+  providers: [TagsService],
+  controllers: [TagsController],
+  exports: [TagsService],
+})
+export class TagsModule {}

--- a/backend/src/tags/tags.service.ts
+++ b/backend/src/tags/tags.service.ts
@@ -1,0 +1,248 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Tag } from '../notes/entities/tag.entity';
+import { NoteTag } from '../notes/entities/note-tag.entity';
+import { Note } from '../notes/entities/note.entity';
+import { NoteLike } from '../notes/entities/note-like.entity';
+import { NoteBookmark } from '../notes/entities/note-bookmark.entity';
+import { TagFollow } from '../notes/entities/tag-follow.entity';
+import { TagDetailDto, TagNoteDto, TagNoteListDto, PopularTagDto } from './dto/tag-detail.dto';
+
+@Injectable()
+export class TagsService {
+  constructor(
+    @InjectRepository(Tag)
+    private tagsRepository: Repository<Tag>,
+    @InjectRepository(NoteTag)
+    private noteTagsRepository: Repository<NoteTag>,
+    @InjectRepository(Note)
+    private notesRepository: Repository<Note>,
+    @InjectRepository(NoteLike)
+    private noteLikesRepository: Repository<NoteLike>,
+    @InjectRepository(NoteBookmark)
+    private noteBookmarksRepository: Repository<NoteBookmark>,
+    @InjectRepository(TagFollow)
+    private tagFollowsRepository: Repository<TagFollow>,
+  ) {}
+
+  async getTagDetail(name: string, currentUserId?: number): Promise<TagDetailDto> {
+    const tag = await this.tagsRepository.findOne({ where: { name } });
+    if (!tag) {
+      throw new NotFoundException(`태그 '${name}'을 찾을 수 없습니다.`);
+    }
+
+    const noteCount = await this.noteTagsRepository
+      .createQueryBuilder('nt')
+      .innerJoin('nt.note', 'note')
+      .where('nt.tagId = :tagId', { tagId: tag.id })
+      .andWhere('note.isPublic = :isPublic', { isPublic: true })
+      .getCount();
+
+    const followerCount = await this.tagFollowsRepository.count({ where: { tagId: tag.id } });
+
+    const isFollowing = currentUserId
+      ? !!(await this.tagFollowsRepository.findOne({ where: { userId: currentUserId, tagId: tag.id } }))
+      : false;
+
+    return { name: tag.name, noteCount, isFollowing, followerCount };
+  }
+
+  async getNotesByTag(name: string, page: number, limit: number, currentUserId?: number): Promise<TagNoteListDto> {
+    const tag = await this.tagsRepository.findOne({ where: { name } });
+    if (!tag) {
+      throw new NotFoundException(`태그 '${name}'을 찾을 수 없습니다.`);
+    }
+
+    const offset = (page - 1) * limit;
+
+    const [noteTags, total] = await this.noteTagsRepository
+      .createQueryBuilder('nt')
+      .innerJoinAndSelect('nt.note', 'note')
+      .innerJoinAndSelect('note.user', 'user')
+      .innerJoinAndSelect('note.tea', 'tea')
+      .leftJoinAndSelect('note.noteTags', 'noteTags')
+      .leftJoinAndSelect('noteTags.tag', 'tag')
+      .where('nt.tagId = :tagId', { tagId: tag.id })
+      .andWhere('note.isPublic = :isPublic', { isPublic: true })
+      .orderBy('note.createdAt', 'DESC')
+      .skip(offset)
+      .take(limit)
+      .getManyAndCount();
+
+    const notes = noteTags.map((nt) => nt.note);
+    const noteIds = notes.map((n) => n.id);
+
+    const likeCountMap = new Map<number, number>();
+    const userLikedSet = new Set<number>();
+    const userBookmarkedSet = new Set<number>();
+
+    if (noteIds.length > 0) {
+      const likeCounts = await this.noteLikesRepository
+        .createQueryBuilder('l')
+        .select('l.noteId', 'noteId')
+        .addSelect('COUNT(l.id)', 'cnt')
+        .where('l.noteId IN (:...noteIds)', { noteIds })
+        .groupBy('l.noteId')
+        .getRawMany();
+      likeCounts.forEach((r) => likeCountMap.set(Number(r.noteId), Number(r.cnt)));
+
+      if (currentUserId) {
+        const userLikes = await this.noteLikesRepository.find({
+          where: { noteId: In(noteIds), userId: currentUserId },
+        });
+        userLikes.forEach((l) => userLikedSet.add(l.noteId));
+
+        const userBookmarks = await this.noteBookmarksRepository.find({
+          where: { noteId: In(noteIds), userId: currentUserId },
+        });
+        userBookmarks.forEach((b) => userBookmarkedSet.add(b.noteId));
+      }
+    }
+
+    const tagDetail = await this.getTagDetail(name, currentUserId);
+
+    const noteDtos: TagNoteDto[] = notes.map((note) => ({
+      id: note.id,
+      teaId: note.teaId,
+      teaName: (note as any).tea?.name ?? '',
+      teaImageUrl: (note as any).tea?.imageUrl ?? null,
+      userId: note.userId,
+      userName: (note as any).user?.name ?? '',
+      userProfileImageUrl: (note as any).user?.profileImageUrl ?? null,
+      overallRating: note.overallRating,
+      memo: note.memo,
+      tags: note.noteTags?.map((nt) => nt.tag?.name).filter(Boolean) ?? [],
+      likeCount: likeCountMap.get(note.id) ?? 0,
+      isLiked: userLikedSet.has(note.id),
+      isBookmarked: userBookmarkedSet.has(note.id),
+      createdAt: note.createdAt,
+    }));
+
+    return { tag: tagDetail, notes: noteDtos, total, page, limit };
+  }
+
+  async getPopularTags(limit: number, currentUserId?: number): Promise<PopularTagDto[]> {
+    const rows = await this.noteTagsRepository
+      .createQueryBuilder('nt')
+      .select('tag.name', 'name')
+      .addSelect('COUNT(nt.id)', 'noteCount')
+      .innerJoin('nt.tag', 'tag')
+      .innerJoin('nt.note', 'note')
+      .where('note.isPublic = :isPublic', { isPublic: true })
+      .groupBy('tag.id')
+      .orderBy('noteCount', 'DESC')
+      .limit(limit)
+      .getRawMany();
+
+    return this.attachFollowingFlag(rows, currentUserId);
+  }
+
+  async getRecentTags(limit: number, currentUserId?: number): Promise<PopularTagDto[]> {
+    const tags = await this.tagsRepository.find({
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+
+    const noteCountRows = await this.noteTagsRepository
+      .createQueryBuilder('nt')
+      .select('nt.tagId', 'tagId')
+      .addSelect('COUNT(nt.id)', 'noteCount')
+      .innerJoin('nt.note', 'note')
+      .where('note.isPublic = :isPublic', { isPublic: true })
+      .andWhere('nt.tagId IN (:...tagIds)', { tagIds: tags.map((t) => t.id) })
+      .groupBy('nt.tagId')
+      .getRawMany();
+
+    const countMap = new Map<number, number>();
+    noteCountRows.forEach((r) => countMap.set(Number(r.tagId), Number(r.noteCount)));
+
+    const rows = tags.map((t) => ({ name: t.name, noteCount: countMap.get(t.id) ?? 0 }));
+    return this.attachFollowingFlag(rows, currentUserId);
+  }
+
+  async followTag(userId: number, name: string): Promise<void> {
+    const tag = await this.tagsRepository.findOne({ where: { name } });
+    if (!tag) {
+      throw new NotFoundException(`태그 '${name}'을 찾을 수 없습니다.`);
+    }
+
+    const existing = await this.tagFollowsRepository.findOne({ where: { userId, tagId: tag.id } });
+    if (existing) {
+      throw new ConflictException('이미 팔로우한 태그입니다.');
+    }
+
+    const follow = this.tagFollowsRepository.create({ userId, tagId: tag.id });
+    await this.tagFollowsRepository.save(follow);
+  }
+
+  async unfollowTag(userId: number, name: string): Promise<void> {
+    const tag = await this.tagsRepository.findOne({ where: { name } });
+    if (!tag) {
+      throw new NotFoundException(`태그 '${name}'을 찾을 수 없습니다.`);
+    }
+
+    const follow = await this.tagFollowsRepository.findOne({ where: { userId, tagId: tag.id } });
+    if (!follow) {
+      throw new NotFoundException('팔로우하지 않은 태그입니다.');
+    }
+
+    await this.tagFollowsRepository.remove(follow);
+  }
+
+  async getFollowedTags(userId: number): Promise<PopularTagDto[]> {
+    const follows = await this.tagFollowsRepository.find({
+      where: { userId },
+      relations: ['tag'],
+      order: { createdAt: 'DESC' },
+    });
+
+    const tagIds = follows.map((f) => f.tagId);
+    if (tagIds.length === 0) return [];
+
+    const noteCountRows = await this.noteTagsRepository
+      .createQueryBuilder('nt')
+      .select('nt.tagId', 'tagId')
+      .addSelect('COUNT(nt.id)', 'noteCount')
+      .innerJoin('nt.note', 'note')
+      .where('note.isPublic = :isPublic', { isPublic: true })
+      .andWhere('nt.tagId IN (:...tagIds)', { tagIds })
+      .groupBy('nt.tagId')
+      .getRawMany();
+
+    const countMap = new Map<number, number>();
+    noteCountRows.forEach((r) => countMap.set(Number(r.tagId), Number(r.noteCount)));
+
+    return follows.map((f) => ({
+      name: f.tag.name,
+      noteCount: countMap.get(f.tagId) ?? 0,
+      isFollowing: true,
+    }));
+  }
+
+  private async attachFollowingFlag(rows: Array<{ name: string; noteCount: number | string }>, currentUserId?: number): Promise<PopularTagDto[]> {
+    if (!currentUserId || rows.length === 0) {
+      return rows.map((r) => ({ name: r.name, noteCount: Number(r.noteCount), isFollowing: false }));
+    }
+
+    const tagNames = rows.map((r) => r.name);
+    const tags = await this.tagsRepository.find({ where: { name: In(tagNames) } });
+    const tagIdMap = new Map(tags.map((t) => [t.name, t.id]));
+
+    const tagIds = tags.map((t) => t.id);
+    if (tagIds.length === 0) {
+      return rows.map((r) => ({ name: r.name, noteCount: Number(r.noteCount), isFollowing: false }));
+    }
+
+    const follows = await this.tagFollowsRepository.find({
+      where: { userId: currentUserId, tagId: In(tagIds) },
+    });
+    const followedTagIds = new Set(follows.map((f) => f.tagId));
+
+    return rows.map((r) => ({
+      name: r.name,
+      noteCount: Number(r.noteCount),
+      isFollowing: followedTagIds.has(tagIdMap.get(r.name) ?? -1),
+    }));
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { EditPost } from './pages/EditPost';
 import { Login } from './pages/Login';
 import { Register } from './pages/Register';
 import { Onboarding } from './pages/Onboarding';
+import { TagDetail } from './pages/TagDetail';
 import { FloatingActionButton } from './components/FloatingActionButton';
 
 type FloatingActionRouteConfig = {
@@ -126,6 +127,7 @@ export default function App() {
               <Route path="/community/new" element={<NewPost />} />
               <Route path="/community/:id" element={<PostDetail />} />
               <Route path="/community/:id/edit" element={<EditPost />} />
+              <Route path="/tag/:name" element={<TagDetail />} />
               <Route path="/settings" element={<Settings />} />
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -2,7 +2,7 @@ import React, { type FC, useState, memo } from 'react';
 import { Star, Lock, Heart, Bookmark, Loader2 } from 'lucide-react';
 import teaCupSvg from '../assets/tea-cup.svg';
 import { Note } from '../types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { ImageWithFallback } from './figma/ImageWithFallback';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
@@ -261,12 +261,14 @@ const NoteCardComponent: FC<NoteCardProps> = ({ note, showTeaName = false, onBoo
           {note.tags && note.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-0">
               {note.tags.slice(0, 5).map((tag, index) => (
-                <span
+                <Link
                   key={index}
-                  className="text-xs px-2.5 py-1 bg-muted text-foreground rounded-full font-medium"
+                  to={`/tag/${encodeURIComponent(tag)}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-xs px-2.5 py-1 bg-muted text-foreground rounded-full font-medium hover:bg-muted/80 transition-colors"
                 >
                   {tag}
-                </span>
+                </Link>
               ))}
               {note.tags.length > 5 && (
                 <span className="text-xs px-2.5 py-1 text-muted-foreground font-medium">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1153,6 +1153,23 @@ export const postsApi = {
     apiClient.post<{ id: number; message: string }>(`/posts/${id}/report`, { reason }),
 };
 
+export const tagsApi = {
+  getPopularTags: (limit = 20) =>
+    apiClient.get<import('../types').PopularTagItem[]>(`/tags/popular?limit=${limit}`),
+  getRecentTags: (limit = 20) =>
+    apiClient.get<import('../types').PopularTagItem[]>(`/tags/recent?limit=${limit}`),
+  getFollowedTags: () =>
+    apiClient.get<import('../types').PopularTagItem[]>('/tags/followed'),
+  getTagDetail: (name: string) =>
+    apiClient.get<import('../types').TagDetail>(`/tags/${encodeURIComponent(name)}`),
+  getTagNotes: (name: string, page = 1, limit = 20) =>
+    apiClient.get<import('../types').TagNoteList>(`/tags/${encodeURIComponent(name)}/notes?page=${page}&limit=${limit}`),
+  followTag: (name: string) =>
+    apiClient.post<void>(`/tags/${encodeURIComponent(name)}/follow`),
+  unfollowTag: (name: string) =>
+    apiClient.delete(`/tags/${encodeURIComponent(name)}/follow`),
+};
+
 export const commentsApi = {
   getByPost: (postId: number) =>
     apiClient.get<import('../types').Comment[]>(`/posts/${postId}/comments`),

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -18,6 +18,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../components/ui/alert-dialog';
+import { Link } from 'react-router-dom';
 import { notesApi, teasApi } from '../lib/api';
 import { Note, Tea } from '../types';
 import { toast } from 'sonner';
@@ -329,9 +330,11 @@ export function NoteDetail() {
             <h3 className="mb-3 text-primary">태그</h3>
             <div className="flex flex-wrap gap-2">
               {note.tags.map((tag, index) => (
-                <Badge key={index} variant="secondary">
-                  {tag}
-                </Badge>
+                <Link key={index} to={`/tag/${encodeURIComponent(tag)}`}>
+                  <Badge variant="secondary" className="cursor-pointer hover:bg-muted/80 transition-colors">
+                    {tag}
+                  </Badge>
+                </Link>
               ))}
             </div>
           </section>

--- a/src/pages/TagDetail.tsx
+++ b/src/pages/TagDetail.tsx
@@ -1,0 +1,385 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { ArrowLeft, Hash, Bell, BellOff, Loader2, Star, Heart, Users } from 'lucide-react';
+import { Header } from '../components/Header';
+import { Button } from '../components/ui/button';
+import { Badge } from '../components/ui/badge';
+import { tagsApi } from '../lib/api';
+import { TagDetail as TagDetailType, TagNoteList, PopularTagItem } from '../types';
+import { useAuth } from '../contexts/AuthContext';
+import { toast } from 'sonner';
+import { logger } from '../lib/logger';
+
+const LIMIT = 20;
+
+export function TagDetail() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [tagDetail, setTagDetail] = useState<TagDetailType | null>(null);
+  const [noteList, setNoteList] = useState<TagNoteList | null>(null);
+  const [popularTags, setPopularTags] = useState<PopularTagItem[]>([]);
+  const [recentTags, setRecentTags] = useState<PopularTagItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isFollowLoading, setIsFollowLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState<'notes' | 'related'>('notes');
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  const decodedName = name ? decodeURIComponent(name) : '';
+
+  const loadInitialData = useCallback(async () => {
+    if (!decodedName) return;
+    setIsLoading(true);
+    try {
+      const [detail, notes, popular, recent] = await Promise.all([
+        tagsApi.getTagDetail(decodedName),
+        tagsApi.getTagNotes(decodedName, 1, LIMIT),
+        tagsApi.getPopularTags(10),
+        tagsApi.getRecentTags(10),
+      ]);
+      setTagDetail(detail);
+      setNoteList(notes);
+      setHasMore(notes.notes.length === LIMIT && notes.total > LIMIT);
+      setPopularTags(popular);
+      setRecentTags(recent);
+      setPage(1);
+    } catch (error: any) {
+      logger.error('Failed to load tag detail:', error);
+      if (error?.statusCode === 404) {
+        toast.error('존재하지 않는 태그입니다.');
+        navigate(-1);
+      } else {
+        toast.error('태그 정보를 불러올 수 없습니다.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [decodedName, navigate]);
+
+  useEffect(() => {
+    loadInitialData();
+  }, [loadInitialData]);
+
+  const handleLoadMore = async () => {
+    if (isLoadingMore || !hasMore || !decodedName) return;
+    setIsLoadingMore(true);
+    try {
+      const nextPage = page + 1;
+      const result = await tagsApi.getTagNotes(decodedName, nextPage, LIMIT);
+      setNoteList((prev) =>
+        prev
+          ? { ...result, notes: [...prev.notes, ...result.notes] }
+          : result,
+      );
+      setPage(nextPage);
+      setHasMore(result.notes.length === LIMIT && (noteList?.notes.length ?? 0) + result.notes.length < result.total);
+    } catch (error: any) {
+      logger.error('Failed to load more notes:', error);
+      toast.error('노트를 더 불러올 수 없습니다.');
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
+
+  const handleFollowToggle = async () => {
+    if (!user) {
+      toast.error('로그인이 필요합니다.');
+      return;
+    }
+    if (!tagDetail || isFollowLoading) return;
+
+    setIsFollowLoading(true);
+    const wasFollowing = tagDetail.isFollowing;
+    try {
+      if (wasFollowing) {
+        await tagsApi.unfollowTag(decodedName);
+        setTagDetail((prev) =>
+          prev
+            ? { ...prev, isFollowing: false, followerCount: Math.max(0, prev.followerCount - 1) }
+            : prev,
+        );
+        toast.success(`#${decodedName} 팔로우를 취소했습니다.`);
+      } else {
+        await tagsApi.followTag(decodedName);
+        setTagDetail((prev) =>
+          prev ? { ...prev, isFollowing: true, followerCount: prev.followerCount + 1 } : prev,
+        );
+        toast.success(`#${decodedName} 태그를 팔로우했습니다.`);
+      }
+    } catch (error: any) {
+      logger.error('Failed to toggle follow:', error);
+      toast.error(wasFollowing ? '팔로우 취소에 실패했습니다.' : '팔로우에 실패했습니다.');
+    } finally {
+      setIsFollowLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <Header title={`#${decodedName}`} />
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!tagDetail) return null;
+
+  const notes = noteList?.notes ?? [];
+  const total = noteList?.total ?? 0;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header title="" />
+
+      {/* 태그 헤더 */}
+      <div className="px-4 pt-2 pb-4 border-b border-border/50">
+        <button
+          onClick={() => navigate(-1)}
+          className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors mb-3 text-sm"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          뒤로
+        </button>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <Hash className="w-5 h-5 text-primary shrink-0" />
+              <h1 className="text-xl font-bold truncate">{decodedName}</h1>
+            </div>
+            <div className="flex items-center gap-3 text-sm text-muted-foreground mt-1">
+              <span className="flex items-center gap-1">
+                <Star className="w-3.5 h-3.5" />
+                노트 {total.toLocaleString()}개
+              </span>
+              <span className="flex items-center gap-1">
+                <Users className="w-3.5 h-3.5" />
+                팔로워 {tagDetail.followerCount.toLocaleString()}명
+              </span>
+            </div>
+          </div>
+
+          <Button
+            variant={tagDetail.isFollowing ? 'outline' : 'default'}
+            size="sm"
+            onClick={handleFollowToggle}
+            disabled={isFollowLoading}
+            className="shrink-0"
+          >
+            {isFollowLoading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : tagDetail.isFollowing ? (
+              <>
+                <BellOff className="w-4 h-4 mr-1.5" />
+                팔로우 중
+              </>
+            ) : (
+              <>
+                <Bell className="w-4 h-4 mr-1.5" />
+                팔로우
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* 탭 */}
+      <div className="flex border-b border-border/50">
+        <button
+          className={`flex-1 py-3 text-sm font-medium transition-colors ${
+            activeTab === 'notes'
+              ? 'text-primary border-b-2 border-primary'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('notes')}
+        >
+          노트 목록
+        </button>
+        <button
+          className={`flex-1 py-3 text-sm font-medium transition-colors ${
+            activeTab === 'related'
+              ? 'text-primary border-b-2 border-primary'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('related')}
+        >
+          관련 태그
+        </button>
+      </div>
+
+      {/* 탭 콘텐츠 */}
+      <div className="pb-24">
+        {activeTab === 'notes' && (
+          <>
+            {notes.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
+                <Hash className="w-10 h-10 mb-3 opacity-30" />
+                <p className="text-sm">이 태그가 달린 공개 노트가 없습니다.</p>
+              </div>
+            ) : (
+              <div className="divide-y divide-border/50">
+                {notes.map((note) => (
+                  <div
+                    key={note.id}
+                    onClick={() => navigate(`/note/${note.id}`)}
+                    className="flex items-start gap-3 px-4 py-3 hover:bg-muted/20 cursor-pointer transition-colors"
+                  >
+                    {/* 차 이미지 */}
+                    <div className="shrink-0 w-16 h-16 rounded-lg overflow-hidden bg-muted flex items-center justify-center">
+                      {note.teaImageUrl ? (
+                        <img src={note.teaImageUrl} alt={note.teaName} className="w-full h-full object-cover" />
+                      ) : (
+                        <Star className="w-6 h-6 text-muted-foreground/40" />
+                      )}
+                    </div>
+
+                    {/* 내용 */}
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-sm text-primary truncate">{note.teaName}</p>
+                      {note.memo && (
+                        <p className="text-sm text-muted-foreground line-clamp-1 mt-0.5">{note.memo}</p>
+                      )}
+                      {note.overallRating !== null && (
+                        <div className="flex items-center gap-1 mt-1">
+                          <Star className="w-3.5 h-3.5 fill-amber-400 text-amber-400" />
+                          <span className="text-xs font-medium">{Number(note.overallRating).toFixed(1)}</span>
+                        </div>
+                      )}
+                      {/* 태그 */}
+                      {note.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-1.5">
+                          {note.tags.slice(0, 4).map((tag) => (
+                            <Link
+                              key={tag}
+                              to={`/tag/${encodeURIComponent(tag)}`}
+                              onClick={(e) => e.stopPropagation()}
+                              className={`text-xs px-2 py-0.5 rounded-full font-medium transition-colors ${
+                                tag === decodedName
+                                  ? 'bg-primary text-primary-foreground'
+                                  : 'bg-muted text-foreground hover:bg-muted/80'
+                              }`}
+                            >
+                              {tag}
+                            </Link>
+                          ))}
+                          {note.tags.length > 4 && (
+                            <span className="text-xs text-muted-foreground">+{note.tags.length - 4}</span>
+                          )}
+                        </div>
+                      )}
+                      {/* 작성자 & 좋아요 */}
+                      <div className="flex items-center justify-between mt-1.5">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            navigate(`/user/${note.userId}`);
+                          }}
+                          className="text-xs text-muted-foreground hover:text-primary transition-colors"
+                        >
+                          {note.userName}
+                          <span className="mx-1">·</span>
+                          {new Date(note.createdAt).toLocaleDateString('ko-KR')}
+                        </button>
+                        {note.likeCount > 0 && (
+                          <span className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                            <Heart className="w-3 h-3" />
+                            {note.likeCount}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+
+                {/* 더 보기 버튼 */}
+                {hasMore && (
+                  <div className="flex justify-center py-4">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleLoadMore}
+                      disabled={isLoadingMore}
+                    >
+                      {isLoadingMore ? (
+                        <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                      ) : null}
+                      더 보기
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+
+        {activeTab === 'related' && (
+          <div className="px-4 py-4 space-y-6">
+            {/* 인기 태그 */}
+            <section>
+              <h2 className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
+                인기 태그
+              </h2>
+              {popularTags.length === 0 ? (
+                <p className="text-sm text-muted-foreground">인기 태그가 없습니다.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {popularTags.map((tag) => (
+                    <Link
+                      key={tag.name}
+                      to={`/tag/${encodeURIComponent(tag.name)}`}
+                      className={`inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                        tag.name === decodedName
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-muted text-foreground hover:bg-muted/80'
+                      }`}
+                    >
+                      <Hash className="w-3 h-3" />
+                      {tag.name}
+                      <span className="text-xs opacity-70">({tag.noteCount})</span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {/* 신규 태그 */}
+            <section>
+              <h2 className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
+                신규 태그
+              </h2>
+              {recentTags.length === 0 ? (
+                <p className="text-sm text-muted-foreground">신규 태그가 없습니다.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {recentTags.map((tag) => (
+                    <Link
+                      key={tag.name}
+                      to={`/tag/${encodeURIComponent(tag.name)}`}
+                      className={`inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                        tag.name === decodedName
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-muted text-foreground hover:bg-muted/80'
+                      }`}
+                    >
+                      <Hash className="w-3 h-3" />
+                      {tag.name}
+                      {tag.noteCount > 0 && (
+                        <span className="text-xs opacity-70">({tag.noteCount})</span>
+                      )}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/TeaDetail.tsx
+++ b/src/pages/TeaDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Star, Loader2 } from 'lucide-react';
 import { Header } from '../components/Header';
 import { NoteCard } from '../components/NoteCard';
@@ -177,7 +177,9 @@ export function TeaDetail() {
               <p className="text-xs text-gray-500 mb-2">특징 요약</p>
               <div className="flex flex-wrap gap-2">
                 {topTags.map((tag) => (
-                  <Badge key={tag} variant="secondary">{tag}</Badge>
+                  <Link key={tag} to={`/tag/${encodeURIComponent(tag)}`}>
+                    <Badge variant="secondary" className="cursor-pointer hover:bg-muted/80 transition-colors">{tag}</Badge>
+                  </Link>
                 ))}
               </div>
             </div>
@@ -207,13 +209,14 @@ export function TeaDetail() {
                       ? 'text-sm font-medium'
                       : 'text-xs';
                 return (
-                  <span
+                  <Link
                     key={tag.name}
-                    className={`inline-flex items-center px-3 py-1 rounded-full bg-emerald-50 text-emerald-700 ${size}`}
+                    to={`/tag/${encodeURIComponent(tag.name)}`}
+                    className={`inline-flex items-center px-3 py-1 rounded-full bg-emerald-50 text-emerald-700 hover:bg-emerald-100 transition-colors ${size}`}
                   >
                     {tag.name}
                     <span className="ml-1 text-emerald-400 text-xs">×{tag.count}</span>
-                  </span>
+                  </Link>
                 );
               })}
             </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,44 @@ export interface Post {
   updatedAt: Date;
 }
 
+export interface TagDetail {
+  name: string;
+  noteCount: number;
+  isFollowing: boolean;
+  followerCount: number;
+}
+
+export interface PopularTagItem {
+  name: string;
+  noteCount: number;
+  isFollowing?: boolean;
+}
+
+export interface TagNoteItem {
+  id: number;
+  teaId: number;
+  teaName: string;
+  teaImageUrl: string | null;
+  userId: number;
+  userName: string;
+  userProfileImageUrl: string | null;
+  overallRating: number | null;
+  memo: string | null;
+  tags: string[];
+  likeCount: number;
+  isLiked: boolean;
+  isBookmarked: boolean;
+  createdAt: Date;
+}
+
+export interface TagNoteList {
+  tag: TagDetail;
+  notes: TagNoteItem[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
 export interface Comment {
   id: number;
   postId: number;


### PR DESCRIPTION
## Summary

- 태그 클릭 시 `/tag/:name` 상세 페이지로 이동 (노트 목록 + 관련 태그 탭)
- 태그 팔로우/언팔로우 기능 구현 (팔로워 수 표시)
- 백엔드 `TagsModule` 신규 생성: popular/recent/followed/detail/notes API 5종
- `NoteCard`, `NoteDetail`, `TeaDetail`의 태그 Badge → `/tag/:name` 링크 처리
- `tag_follows` 테이블 + 마이그레이션 파일 추가

## Test plan

- [ ] `/tag/:name` 페이지 진입 확인 (NoteCard 태그 클릭)
- [ ] 노트 목록 탭: 해당 태그가 달린 공개 노트 표시, 더 보기 동작
- [ ] 관련 태그 탭: 인기 태그 / 신규 태그 pill 표시 및 클릭 이동
- [ ] 팔로우 버튼: 로그인 시 팔로우/언팔로우 토글, 팔로워 수 즉시 반영
- [ ] 비로그인 시 팔로우 클릭 → 로그인 필요 토스트
- [ ] `GET /tags/popular`, `GET /tags/recent`, `GET /tags/followed` API 응답 확인
- [ ] `POST/DELETE /tags/:name/follow` API 동작 확인
- [ ] DB 마이그레이션 실행 후 `tag_follows` 테이블 생성 확인

Closes #33

Made with [Cursor](https://cursor.com)