### PR TITLE
feat: [3단계] 프로필 커스터마이징 (#43)

### DIFF
--- a/backend/migrations/1790000000000-AddProfileCustomizationFields.ts
+++ b/backend/migrations/1790000000000-AddProfileCustomizationFields.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProfileCustomizationFields1790000000000
+  implements MigrationInterface
+{
+  name = 'AddProfileCustomizationFields1790000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const addColumnIfNotExists = async (
+      table: string,
+      column: string,
+      definition: string,
+    ) => {
+      const rows: Array<Record<string, number>> = await queryRunner.query(
+        `SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '${table}' AND COLUMN_NAME = '${column}' LIMIT 1`,
+      );
+      if (rows.length === 0) {
+        await queryRunner.query(
+          `ALTER TABLE \`${table}\` ADD \`${column}\` ${definition}`,
+        );
+      }
+    };
+
+    await addColumnIfNotExists('users', 'bio', 'varchar(150) NULL');
+    await addColumnIfNotExists('users', 'instagramUrl', 'varchar(500) NULL');
+    await addColumnIfNotExists('users', 'blogUrl', 'varchar(500) NULL');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const dropColumnIfExists = async (table: string, column: string) => {
+      const rows: Array<Record<string, number>> = await queryRunner.query(
+        `SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '${table}' AND COLUMN_NAME = '${column}' LIMIT 1`,
+      );
+      if (rows.length > 0) {
+        await queryRunner.query(
+          `ALTER TABLE \`${table}\` DROP COLUMN \`${column}\``,
+        );
+      }
+    };
+
+    await dropColumnIfExists('users', 'blogUrl');
+    await dropColumnIfExists('users', 'instagramUrl');
+    await dropColumnIfExists('users', 'bio');
+  }
+}

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -3,9 +3,26 @@ import { IsOptional, IsString, MaxLength } from 'class-validator';
 export class UpdateUserDto {
   @IsOptional()
   @IsString()
+  @MaxLength(50)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
   @MaxLength(500)
   profileImageUrl?: string | null;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(150)
+  bio?: string | null;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  instagramUrl?: string | null;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  blogUrl?: string | null;
 }
-
-
-

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -21,6 +21,15 @@ export class User {
   @Column({ type: 'varchar', length: 500, nullable: true })
   profileImageUrl: string | null;
 
+  @Column({ type: 'varchar', length: 150, nullable: true })
+  bio: string | null;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  instagramUrl: string | null;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  blogUrl: string | null;
+
   @OneToMany(() => UserAuthentication, (auth) => auth.user, { cascade: true })
   authentications: UserAuthentication[];
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -241,9 +241,20 @@ export class UsersService {
       throw new ForbiddenException('이 프로필을 수정할 권한이 없습니다.');
     }
 
-    // 프로필 이미지 URL 업데이트
+    if (updateUserDto.name !== undefined) {
+      user.name = updateUserDto.name;
+    }
     if (updateUserDto.profileImageUrl !== undefined) {
       user.profileImageUrl = updateUserDto.profileImageUrl;
+    }
+    if (updateUserDto.bio !== undefined) {
+      user.bio = updateUserDto.bio;
+    }
+    if (updateUserDto.instagramUrl !== undefined) {
+      user.instagramUrl = updateUserDto.instagramUrl;
+    }
+    if (updateUserDto.blogUrl !== undefined) {
+      user.blogUrl = updateUserDto.blogUrl;
     }
 
     return await this.usersRepository.save(user);

--- a/src/components/ProfileEditModal.tsx
+++ b/src/components/ProfileEditModal.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from './ui/dialog';
+import { Button } from './ui/button';
+import { usersApi } from '../lib/api';
+import { toast } from 'sonner';
+import { User } from '../types';
+
+interface ProfileEditModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  user: User;
+  onSuccess: (updatedUser: Partial<User>) => void;
+}
+
+export function ProfileEditModal({
+  open,
+  onOpenChange,
+  user,
+  onSuccess,
+}: ProfileEditModalProps) {
+  const [saving, setSaving] = useState(false);
+  const [name, setName] = useState(user.name ?? '');
+  const [bio, setBio] = useState(user.bio ?? '');
+  const [instagramUrl, setInstagramUrl] = useState(user.instagramUrl ?? '');
+  const [blogUrl, setBlogUrl] = useState(user.blogUrl ?? '');
+
+  useEffect(() => {
+    if (open) {
+      setName(user.name ?? '');
+      setBio(user.bio ?? '');
+      setInstagramUrl(user.instagramUrl ?? '');
+      setBlogUrl(user.blogUrl ?? '');
+    }
+  }, [open, user]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) {
+      toast.error('이름을 입력해주세요.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await usersApi.updateProfile(user.id, {
+        name: name.trim(),
+        bio: bio.trim() || null,
+        instagramUrl: instagramUrl.trim() || null,
+        blogUrl: blogUrl.trim() || null,
+      });
+
+      toast.success('프로필이 업데이트되었습니다.');
+      onSuccess({
+        name: name.trim(),
+        bio: bio.trim() || null,
+        instagramUrl: instagramUrl.trim() || null,
+        blogUrl: blogUrl.trim() || null,
+      });
+      onOpenChange(false);
+    } catch {
+      toast.error('프로필 업데이트에 실패했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-sm p-0 overflow-hidden [&>button]:top-4 [&>button]:right-4">
+        <DialogHeader className="text-center px-6 pt-6 pb-4 pr-12">
+          <DialogTitle className="text-lg font-semibold tracking-tight">프로필 편집</DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground mt-1.5 font-normal">
+            이름, 자기소개, 소셜 링크를 수정할 수 있습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="px-6 pb-6 space-y-4">
+          <div className="space-y-1.5">
+            <label htmlFor="profile-name" className="text-sm font-medium text-foreground">
+              이름 <span className="text-destructive">*</span>
+            </label>
+            <input
+              id="profile-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={50}
+              placeholder="이름을 입력하세요"
+              disabled={saving}
+              className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent disabled:opacity-50 transition-colors"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="profile-bio" className="text-sm font-medium text-foreground">
+              한 줄 자기소개
+            </label>
+            <div className="relative">
+              <input
+                id="profile-bio"
+                type="text"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                maxLength={150}
+                placeholder="차에 대한 짧은 소개를 남겨보세요"
+                disabled={saving}
+                className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent disabled:opacity-50 transition-colors pr-12"
+              />
+              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">
+                {bio.length}/150
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="profile-instagram" className="text-sm font-medium text-foreground">
+              인스타그램
+            </label>
+            <input
+              id="profile-instagram"
+              type="url"
+              value={instagramUrl}
+              onChange={(e) => setInstagramUrl(e.target.value)}
+              maxLength={500}
+              placeholder="https://instagram.com/yourname"
+              disabled={saving}
+              className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent disabled:opacity-50 transition-colors"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="profile-blog" className="text-sm font-medium text-foreground">
+              블로그 / 웹사이트
+            </label>
+            <input
+              id="profile-blog"
+              type="url"
+              value={blogUrl}
+              onChange={(e) => setBlogUrl(e.target.value)}
+              maxLength={500}
+              placeholder="https://myblog.com"
+              disabled={saving}
+              className="w-full h-10 px-3 rounded-lg border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent disabled:opacity-50 transition-colors"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2 pt-2">
+            <Button
+              type="submit"
+              disabled={saving}
+              className="w-full h-11 rounded-xl text-sm font-medium active:scale-[0.98] transition-all duration-200 shadow-sm"
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span>저장 중...</span>
+                </>
+              ) : (
+                <span>저장</span>
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={saving}
+              onClick={() => onOpenChange(false)}
+              className="w-full h-11 rounded-xl text-sm font-medium"
+            >
+              취소
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1095,7 +1095,7 @@ export interface UserNotificationSetting {
 export const usersApi = {
   getById: (id: number) => apiClient.get<User>(`/users/${id}`),
   uploadProfileImage: (file: File) => apiClient.uploadFile<{ url: string }>('/users/profile-image', file),
-  updateProfile: (id: number, data: { profileImageUrl?: string | null }) => apiClient.patch<User>(`/users/${id}`, data),
+  updateProfile: (id: number, data: { name?: string; profileImageUrl?: string | null; bio?: string | null; instagramUrl?: string | null; blogUrl?: string | null }) => apiClient.patch<User>(`/users/${id}`, data),
   getOnboardingPreference: (id: number) => apiClient.get<UserOnboardingPreference>(`/users/${id}/onboarding`),
   updateOnboardingPreference: (
     id: number,

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -14,13 +14,14 @@ import { BottomNav } from '../components/BottomNav';
 import { usersApi, notesApi, followsApi } from '../lib/api';
 import { User, Note, UserOnboardingPreference } from '../types';
 import { toast } from 'sonner';
-import { Loader2, Star, Heart, FileText, Camera } from 'lucide-react';
+import { Loader2, Star, Heart, FileText, Camera, Instagram, Globe, Pencil } from 'lucide-react';
 import { logger } from '../lib/logger';
 import { UserAvatar } from '../components/ui/UserAvatar';
 import { StatCard } from '../components/ui/StatCard';
 import { Card } from '../components/ui/card';
 import { Section } from '../components/ui/Section';
 import { ProfileImageEditModal } from '../components/ProfileImageEditModal';
+import { ProfileEditModal } from '../components/ProfileEditModal';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
@@ -37,6 +38,7 @@ export function UserProfile() {
   const [isLoading, setIsLoading] = useState(true);
   const [sort, setSort] = useState<SortType>('latest');
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
   const [isFollowLoading, setIsFollowLoading] = useState(false);
   const [onboardingPreference, setOnboardingPreference] = useState<UserOnboardingPreference | null>(null);
 
@@ -179,6 +181,12 @@ export function UserProfile() {
     }
   };
 
+  const handleProfileInfoUpdate = (updatedFields: Partial<User>) => {
+    if (user) {
+      setUser({ ...user, ...updatedFields });
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background pb-20 flex items-center justify-center">
@@ -225,7 +233,49 @@ export function UserProfile() {
               )}
             </div>
             <div className="flex flex-col items-center text-center gap-2">
-              <h2 className="text-lg sm:text-xl font-semibold text-primary">{user.name}</h2>
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg sm:text-xl font-semibold text-primary">{user.name}</h2>
+                {isOwnProfile && (
+                  <Button
+                    onClick={() => setIsProfileEditModalOpen(true)}
+                    size="icon"
+                    variant="ghost"
+                    className="w-7 h-7 rounded-full text-muted-foreground hover:text-foreground"
+                    aria-label="프로필 편집"
+                  >
+                    <Pencil className="w-3.5 h-3.5" />
+                  </Button>
+                )}
+              </div>
+              {user.bio && (
+                <p className="text-sm text-muted-foreground max-w-[240px] leading-snug">{user.bio}</p>
+              )}
+              {(user.instagramUrl || user.blogUrl) && (
+                <div className="flex items-center gap-2">
+                  {user.instagramUrl && (
+                    <a
+                      href={user.instagramUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="인스타그램"
+                    >
+                      <Instagram className="w-3.5 h-3.5" />
+                    </a>
+                  )}
+                  {user.blogUrl && (
+                    <a
+                      href={user.blogUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="블로그"
+                    >
+                      <Globe className="w-3.5 h-3.5" />
+                    </a>
+                  )}
+                </div>
+              )}
               <div className="flex items-center gap-4 text-sm text-muted-foreground">
                 <span>팔로워 {(user.followerCount ?? 0).toLocaleString('ko-KR')}</span>
                 <span>팔로잉 {(user.followingCount ?? 0).toLocaleString('ko-KR')}</span>
@@ -259,6 +309,16 @@ export function UserProfile() {
             currentImageUrl={user.profileImageUrl}
             onSuccess={handleProfileImageUpdate}
             userId={user.id}
+          />
+        )}
+
+        {/* 프로필 정보 편집 모달 */}
+        {isOwnProfile && user && (
+          <ProfileEditModal
+            open={isProfileEditModalOpen}
+            onOpenChange={setIsProfileEditModalOpen}
+            user={user}
+            onSuccess={handleProfileInfoUpdate}
           />
         )}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,9 @@ export interface User {
   name: string;
   email: string | null;
   profileImageUrl?: string | null;
+  bio?: string | null;
+  instagramUrl?: string | null;
+  blogUrl?: string | null;
   followerCount?: number;
   followingCount?: number;
   isFollowing?: boolean;


### PR DESCRIPTION
## Summary

- `users` 테이블에 `bio`(한 줄 자기소개, 150자), `instagramUrl`, `blogUrl` 컬럼 추가 (TypeORM 마이그레이션 포함)
- `UpdateUserDto` 및 `UsersService.update()`에 신규 필드(`name`, `bio`, `instagramUrl`, `blogUrl`) 반영
- 프론트엔드 `User` 타입 및 `usersApi.updateProfile()` 시그니처 확장
- `ProfileEditModal` 신규 컴포넌트 — 이름, 한 줄 자기소개, 인스타그램, 블로그 편집 폼
- `UserProfile` 페이지에 bio 표시, 소셜 링크 아이콘(Instagram/Globe), 연필 아이콘 편집 버튼 추가

## Changes

### Backend
- `backend/migrations/1790000000000-AddProfileCustomizationFields.ts` — DB 마이그레이션
- `backend/src/users/entities/user.entity.ts` — `bio`, `instagramUrl`, `blogUrl` 컬럼 추가
- `backend/src/users/dto/update-user.dto.ts` — `name`, `bio`, `instagramUrl`, `blogUrl` 필드 추가
- `backend/src/users/users.service.ts` — `update()` 메서드에 신규 필드 처리 추가

### Frontend
- `src/types/index.ts` — `User` 인터페이스 확장
- `src/lib/api.ts` — `usersApi.updateProfile()` 타입 확장
- `src/components/ProfileEditModal.tsx` — 신규 편집 모달 컴포넌트
- `src/pages/UserProfile.tsx` — bio/소셜 링크 표시 + 편집 버튼 연결

## Test plan

- [x] 본인 프로필 페이지에서 연필 아이콘 클릭 → `ProfileEditModal` 열림 확인
- [x] 이름/자기소개/인스타그램/블로그 수정 후 저장 → 프로필 페이지 즉시 반영 확인
- [x] bio가 있을 때 이름 아래에 표시되는지 확인
- [x] 인스타그램/블로그 링크 아이콘이 올바른 URL로 새 탭에서 열리는지 확인
- [x] 타인 프로필에서는 편집 버튼이 노출되지 않는지 확인
- [x] DB 마이그레이션 실행 후 `users` 테이블에 신규 컬럼 존재 확인

Closes #43

Made with [Cursor](https://cursor.com)