### PR TITLE
feat: 차종 통합 및 CSV 기반 시드 스크립트 추가

### DIFF
--- a/backend/scripts/seed-notes-from-csv.js
+++ b/backend/scripts/seed-notes-from-csv.js
@@ -1,0 +1,182 @@
+/**
+ * CSV 테이스팅 노트 데이터를 user 1의 notes로 삽입하는 스크립트
+ *
+ * 사용법:
+ *   DATABASE_URL=mysql://chalog_user:...@127.0.0.1:3307/chalog node backend/scripts/seed-notes-from-csv.js
+ *
+ * 스키마 매핑:
+ *   스키마2 (CUSTOM): 두터움(BODY), 밀도(DENSITY), 매끄러움(SMOOTHNESS), 맑음(CLARITY), 다채로움(COMPLEXITY)
+ *   스키마3 (TASTING_NOTE_V1): 섬세함(DELICACY), 순정함(PURITY), 향의 길이(FINISH), 향탕일체(HARMONY), 개인점수(OVERALL)
+ */
+
+const mysql = require('mysql2/promise');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../.env') });
+
+const USER_ID = 1;
+
+const parseDatabaseUrl = () => {
+  const url = process.env.DATABASE_URL;
+  if (url) {
+    try {
+      const u = new URL(url);
+      return { host: u.hostname, port: u.port ? parseInt(u.port) : 3306, user: u.username, password: u.password || undefined, database: u.pathname.slice(1) };
+    } catch (e) { throw new Error(`Invalid DATABASE_URL: ${e.message}`); }
+  }
+  return { host: process.env.DB_HOST || 'localhost', port: parseInt(process.env.DB_PORT || '3307'), user: process.env.DB_USER || 'chalog_user', password: process.env.DB_PASSWORD, database: process.env.DB_NAME || 'chalog' };
+};
+
+function parseCSVLine(line) {
+  const result = [];
+  let cur = '', inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') { cur += '"'; i++; }
+      else inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) { result.push(cur); cur = ''; }
+    else cur += ch;
+  }
+  result.push(cur);
+  return result;
+}
+
+function parseCSV(content) {
+  const lines = content.split('\n');
+  const headers = parseCSVLine(lines[0].replace(/^\uFEFF/, ''));
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const values = parseCSVLine(line);
+    const row = {};
+    headers.forEach((h, idx) => { row[h] = (values[idx] || '').trim(); });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function parseFloat_(v) {
+  if (!v) return null;
+  const n = parseFloat(v);
+  if (isNaN(n) || n < 1 || n > 10) return null; // 범위 벗어난 값 무시
+  return n;
+}
+
+async function main() {
+  const csvPath = path.join(__dirname, '../../차 테이스팅 노트 28d373699e6680c98cd6e05aad81e7d0_all.csv');
+  if (!fs.existsSync(csvPath)) { console.error('CSV 파일을 찾을 수 없습니다:', csvPath); process.exit(1); }
+
+  const rows = parseCSV(fs.readFileSync(csvPath, 'utf-8'));
+
+  const dbConfig = parseDatabaseUrl();
+  console.log(`DB 연결: ${dbConfig.host}:${dbConfig.port}/${dbConfig.database}\n`);
+  const conn = await mysql.createConnection({ ...dbConfig, multipleStatements: true });
+
+  try {
+    // teas 목록 로드 (name+type → id 매핑)
+    const [teaRows] = await conn.execute('SELECT id, name, type FROM teas');
+    const teaMap = {};
+    for (const t of teaRows) {
+      teaMap[`${t.name}__${t.type}`] = t.id;
+      teaMap[t.name] = t.id; // fallback
+    }
+
+    // axis id 로드
+    const [axisRows] = await conn.execute('SELECT id, schemaId, code FROM rating_axis');
+    const axisMap = {}; // schemaId__code → id
+    for (const a of axisRows) axisMap[`${a.schemaId}__${a.code}`] = a.id;
+
+    // 종류 → DB type 매핑
+    const typeMap = { '녹차': '녹차', '청차': '청차', '백차': '백차', '홍차': '홍차', '흑차': '흑차', '대용': '대용' };
+
+    let inserted = 0, skipped = 0;
+
+    for (const r of rows) {
+      const nameRaw = r['이름'] || '';
+      const teaType = r['종류'] || '';
+      if (!nameRaw || !teaType) continue;
+
+      const name = nameRaw.replace(/^[\d?]+\s+/, '').trim().replace(/혜원갱/g, '해원갱');
+      const memo = r['특징 요약'].trim() || null;
+
+      // tea 매핑: name+type 우선, fallback name만
+      const teaId = teaMap[`${name}__${teaType}`] ?? teaMap[name] ?? null;
+      if (!teaId) {
+        console.log(`  - tea 없음 (스킵): ${name} (${teaType})`);
+        skipped++;
+        continue;
+      }
+
+      // 이미 해당 teaId+userId note 존재하면 스킵
+      const [existing] = await conn.execute('SELECT id FROM notes WHERE userId = ? AND teaId = ?', [USER_ID, teaId]);
+      if (existing.length > 0) {
+        console.log(`  - 이미 존재 (스킵): ${name}`);
+        skipped++;
+        continue;
+      }
+
+      // 스키마2 axis 값
+      const s2Values = {
+        BODY:       parseFloat_(r['두터움']),
+        DENSITY:    parseFloat_(r['밀도']),
+        SMOOTHNESS: parseFloat_(r['매끄러움']),
+        CLARITY:    parseFloat_(r['맑음']),
+        COMPLEXITY: parseFloat_(r['다채로움']),
+      };
+      // 스키마3 axis 값
+      const s3Values = {
+        DELICACY: parseFloat_(r['섬세함']),
+        PURITY:   parseFloat_(r['순정함']),
+        FINISH:   parseFloat_(r['향의 길이']),
+        HARMONY:  parseFloat_(r['향탕일체']),
+        OVERALL:  parseFloat_(r['개인점수']),
+      };
+
+      const hasS2 = Object.values(s2Values).some(v => v !== null);
+      const hasS3 = Object.values(s3Values).some(v => v !== null);
+
+      // schemaId 결정: s2 값이 있으면 2, s3 값이 있으면 3, 둘 다 없으면 3(기본)
+      const schemaId = hasS2 ? 2 : 3;
+
+      // overallRating: 개인점수 있으면 사용, 없으면 axis 평균
+      let overallRating = parseFloat_(r['개인점수']);
+      if (overallRating === null && hasS2) {
+        const vals = Object.values(s2Values).filter(v => v !== null);
+        if (vals.length) overallRating = Math.round(vals.reduce((a, b) => a + b, 0) / vals.length * 10) / 10;
+      }
+
+      // note 삽입
+      const [noteResult] = await conn.execute(
+        'INSERT INTO notes (teaId, userId, memo, isPublic, schemaId, overallRating, isRatingIncluded, createdAt, updatedAt) VALUES (?, ?, ?, 0, ?, ?, 1, NOW(), NOW())',
+        [teaId, USER_ID, memo, schemaId, overallRating]
+      );
+      const noteId = noteResult.insertId;
+
+      // axis 값 삽입
+      const axisEntries = schemaId === 2
+        ? Object.entries(s2Values)
+        : Object.entries(s3Values);
+
+      for (const [code, val] of axisEntries) {
+        if (val === null) continue;
+        const axisId = axisMap[`${schemaId}__${code}`];
+        if (!axisId) continue;
+        await conn.execute(
+          'INSERT INTO note_axis_value (noteId, axisId, valueNumeric, createdAt, updatedAt) VALUES (?, ?, ?, NOW(), NOW())',
+          [noteId, axisId, val]
+        );
+      }
+
+      console.log(`  ✓ ${name} (schema${schemaId}, rating=${overallRating ?? '-'}, axes=${axisEntries.filter(([, v]) => v !== null).length}개)`);
+      inserted++;
+    }
+
+    console.log(`\n완료: ${inserted}개 삽입, ${skipped}개 스킵\n`);
+  } finally {
+    await conn.end();
+  }
+}
+
+main().catch(e => { console.error('오류:', e.message); process.exit(1); });

--- a/backend/scripts/seed-teas-from-csv.js
+++ b/backend/scripts/seed-teas-from-csv.js
@@ -1,0 +1,214 @@
+/**
+ * CSV 테이스팅 노트 데이터를 로컬 teas/sellers 테이블에 삽입하는 스크립트
+ *
+ * 사용법:
+ *   node backend/scripts/seed-teas-from-csv.js
+ *
+ * 전제조건:
+ *   - SSH 터널 또는 로컬 DB가 실행 중이어야 합니다
+ *   - backend/.env 또는 루트 .env 에 DATABASE_URL (또는 DB_* 환경변수) 설정
+ */
+
+const mysql = require('mysql2/promise');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../.env') });
+
+// ─── DB 연결 설정 ────────────────────────────────────────────────────────────
+
+const parseDatabaseUrl = () => {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (databaseUrl) {
+    try {
+      const url = new URL(databaseUrl);
+      return {
+        host: url.hostname,
+        port: url.port ? parseInt(url.port, 10) : 3306,
+        user: url.username,
+        password: url.password || undefined,
+        database: url.pathname.slice(1),
+      };
+    } catch (error) {
+      throw new Error(`Invalid DATABASE_URL: ${error.message}`);
+    }
+  }
+  return {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '3307', 10),
+    user: process.env.DB_USER || 'admin',
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME || 'chalog',
+  };
+};
+
+// ─── CSV 파싱 ─────────────────────────────────────────────────────────────────
+
+function parseCSV(content) {
+  const lines = content.split('\n');
+
+  // BOM 제거 후 헤더 파싱
+  const headerLine = lines[0].replace(/^\uFEFF/, '');
+  const headers = parseCSVLine(headerLine);
+
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const values = parseCSVLine(line);
+    const row = {};
+    headers.forEach((h, idx) => {
+      row[h] = (values[idx] || '').trim();
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function parseCSVLine(line) {
+  const result = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        cur += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === ',' && !inQuotes) {
+      result.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  result.push(cur);
+  return result;
+}
+
+// ─── 데이터 변환 ──────────────────────────────────────────────────────────────
+
+function transformRows(rows) {
+  const sellers = new Set();
+  const teas = [];
+
+  for (const r of rows) {
+    const nameRaw = r['이름'] || '';
+    const sellerName = r['제조사'] || '';
+    const teaType = r['종류'] || '';
+    const priceRaw = r['가격'] || '';
+
+    if (!nameRaw || !teaType) continue;
+
+    // 앞 숫자/? 접두사 제거 → 차 이름
+    const name = nameRaw.replace(/^[\d?]+\s+/, '').trim();
+
+    // 2자리 연도 추출 (예: "24 여산운무" → 2024)
+    const yearMatch = nameRaw.match(/^(\d{2})\s+/);
+    const year = yearMatch ? 2000 + parseInt(yearMatch[1], 10) : null;
+
+    // 가격 파싱 (₩400,000 → 400000)
+    let price = null;
+    if (priceRaw) {
+      const priceClean = priceRaw.replace(/[₩,\s]/g, '');
+      const parsed = parseInt(priceClean, 10);
+      if (!isNaN(parsed)) price = parsed;
+    }
+
+    if (sellerName) sellers.add(sellerName);
+
+    teas.push({
+      name,
+      year,
+      type: teaType,
+      seller: sellerName || null,
+      price,
+    });
+  }
+
+  return { sellers: [...sellers].sort(), teas };
+}
+
+// ─── DB 삽입 ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const csvPath = path.join(
+    __dirname,
+    '../../차 테이스팅 노트 28d373699e6680c98cd6e05aad81e7d0_all.csv',
+  );
+
+  if (!fs.existsSync(csvPath)) {
+    console.error(`CSV 파일을 찾을 수 없습니다: ${csvPath}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(csvPath, 'utf-8');
+  const rows = parseCSV(content);
+  const { sellers, teas } = transformRows(rows);
+
+  console.log(`\n파싱 완료: sellers ${sellers.length}개, teas ${teas.length}개\n`);
+
+  const dbConfig = parseDatabaseUrl();
+  console.log(`DB 연결: ${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`);
+
+  const connection = await mysql.createConnection(dbConfig);
+
+  try {
+    // 1. Sellers 삽입 (중복 무시)
+    console.log('\n[1/2] Sellers 삽입...');
+    for (const sellerName of sellers) {
+      await connection.execute(
+        'INSERT IGNORE INTO sellers (name, createdAt) VALUES (?, NOW(6))',
+        [sellerName],
+      );
+      console.log(`  ✓ seller: ${sellerName}`);
+    }
+
+    // sellerId 조회용 맵 생성
+    const [sellerRows] = await connection.execute('SELECT id, name FROM sellers');
+    const sellerMap = {};
+    for (const row of sellerRows) {
+      sellerMap[row.name] = row.id;
+    }
+
+    // 2. Teas 삽입 (중복 무시: name + type 기준)
+    console.log('\n[2/2] Teas 삽입...');
+    let inserted = 0;
+    let skipped = 0;
+
+    for (const tea of teas) {
+      const sellerId = tea.seller ? (sellerMap[tea.seller] ?? null) : null;
+
+      const [existing] = await connection.execute(
+        'SELECT id FROM teas WHERE name = ? AND type = ?',
+        [tea.name, tea.type],
+      );
+
+      if (existing.length > 0) {
+        console.log(`  - 이미 존재 (스킵): ${tea.name} (${tea.type})`);
+        skipped++;
+        continue;
+      }
+
+      await connection.execute(
+        `INSERT INTO teas (name, year, type, sellerId, price, averageRating, reviewCount, createdAt, updatedAt)
+         VALUES (?, ?, ?, ?, ?, 0, 0, NOW(), NOW())`,
+        [tea.name, tea.year ?? null, tea.type, sellerId, tea.price ?? null],
+      );
+
+      console.log(`  ✓ ${tea.name} (${tea.type}, ${tea.year ?? '-'}, ${tea.price ? `₩${tea.price.toLocaleString()}` : '-'})`);
+      inserted++;
+    }
+
+    console.log(`\n완료: ${inserted}개 삽입, ${skipped}개 스킵\n`);
+  } finally {
+    await connection.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('오류 발생:', err.message);
+  process.exit(1);
+});

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -52,18 +52,17 @@ export const RECOMMENDED_NOTE_TAGS = [
   '온화함', '상쾌함', '따뜻함', '시원함', '은은함', '강렬함'
 ] as const;
 
-// 차 종류 (산화도 낮은 순: 녹→백→황→청(우롱)→홍→흑, + 보이차·대용차)
-export const TEA_TYPES = ['녹차', '백차', '황차', '우롱차', '홍차', '흑차', '보이차', '대용차'] as const;
+// 차 종류 (산화도 낮은 순: 녹→백→황→청/우롱→홍→흑/보이, + 대용차)
+export const TEA_TYPES = ['녹차', '백차', '황차', '청차/우롱차', '홍차', '흑차/보이차', '대용차'] as const;
 
 /** 차 종류별 색상 (칩/배지용) - 파스텔 톤, 차 색감 연상 */
 export const TEA_TYPE_COLORS: Record<(typeof TEA_TYPES)[number], string> = {
   녹차: 'bg-emerald-300 dark:bg-emerald-400',
   백차: 'bg-stone-200 dark:bg-stone-400',
   황차: 'bg-amber-300 dark:bg-amber-400',
-  우롱차: 'bg-blue-400 dark:bg-blue-500',
+  '청차/우롱차': 'bg-blue-400 dark:bg-blue-500',
   홍차: 'bg-rose-300 dark:bg-rose-400',
-  흑차: 'bg-slate-400 dark:bg-slate-500',
-  보이차: 'bg-amber-500 dark:bg-amber-600',
+  '흑차/보이차': 'bg-amber-500 dark:bg-amber-600',
   대용차: 'bg-slate-300 dark:bg-slate-500',
 };
 
@@ -72,10 +71,9 @@ export const TEA_TYPE_PLACEHOLDER_BG: Record<(typeof TEA_TYPES)[number], string>
   녹차: 'bg-emerald-300/40 dark:bg-emerald-400/30',
   백차: 'bg-stone-200/80 dark:bg-stone-400/30',
   황차: 'bg-amber-300/40 dark:bg-amber-400/30',
-  우롱차: 'bg-blue-400/40 dark:bg-blue-500/30',
+  '청차/우롱차': 'bg-blue-400/40 dark:bg-blue-500/30',
   홍차: 'bg-rose-300/40 dark:bg-rose-400/30',
-  흑차: 'bg-slate-400/40 dark:bg-slate-500/30',
-  보이차: 'bg-amber-500/40 dark:bg-amber-600/30',
+  '흑차/보이차': 'bg-amber-500/40 dark:bg-amber-600/30',
   대용차: 'bg-slate-300/40 dark:bg-slate-500/30',
 };
 
@@ -84,10 +82,9 @@ export const TEA_TYPE_TEXT_COLORS: Record<(typeof TEA_TYPES)[number], string> = 
   녹차: 'text-emerald-700 dark:text-emerald-400',
   백차: 'text-stone-600 dark:text-stone-400',
   황차: 'text-amber-700 dark:text-amber-400',
-  우롱차: 'text-blue-600 dark:text-blue-400',
+  '청차/우롱차': 'text-blue-600 dark:text-blue-400',
   홍차: 'text-rose-700 dark:text-rose-400',
-  흑차: 'text-slate-600 dark:text-slate-400',
-  보이차: 'text-amber-800 dark:text-amber-500',
+  '흑차/보이차': 'text-amber-800 dark:text-amber-500',
   대용차: 'text-slate-600 dark:text-slate-400',
 };
 
@@ -104,10 +101,9 @@ export const TEA_TYPE_ORIGINS: Record<(typeof TEA_TYPES)[number], readonly strin
   녹차: ['한국 제주도', '한국 보성', '한국 하동', '일본 시즈오카', '일본 교토 우지', '일본 가고시마', '중국 용정', '중국 푸젠', '대만 핑린', '베트남 탄응옌'],
   백차: ['중국 푸젠 복정', '중국 푸젠 정화', '중국 푸젠 무이산', '대만 핑린', '중국 건강', '인도 다즐링'],
   황차: ['중국 쓰촨 몽정산', '중국 푸젠', '중국 쓰촨', '중국 후난', '대만'],
-  우롱차: ['중국 운남성', '중국 푸젠 무이산', '중국 푸젠 안시', '대만 동정', '대만 문산', '대만 아리산', '중국 광동 펑황단총'],
+  '청차/우롱차': ['중국 푸젠 무이산', '중국 푸젠 안시', '중국 광동 펑황단총', '중국 운남성', '대만 동정', '대만 문산', '대만 아리산'],
   홍차: ['인도 다즐링', '인도 아삼', '인도 닐기리', '스리랑카 누완엘리야', '스리랑카 실론', '케냐', '중국 운남', '중국 푸젠', '대만 동정'],
-  흑차: ['중국 운남 시솽반나', '중국 운남 란창강', '중국 안후이 안화', '중국 후난 안화', '중국 운남', '중국 후난'],
-  보이차: ['중국 운남성 시솽반나', '중국 운남성 란창강', '중국 운남성', '미얀마', '라오스', '베트남'],
+  '흑차/보이차': ['중국 운남성 시솽반나', '중국 운남성 란창강', '중국 운남성', '중국 안후이 안화', '중국 후난 안화', '미얀마', '라오스', '베트남'],
   대용차: ['한국 제주도', '한국 보성', '중국 구이저우', '일본 홋카이도', '대만 핑린', '인도 다즐링', '베트남 탄응옌'],
 };
 


### PR DESCRIPTION
## Summary
- 차종 `우롱차` → `청차/우롱차`, `흑차` + `보이차` → `흑차/보이차` 로 통합
- `TEA_TYPES`, `TEA_TYPE_COLORS`, `TEA_TYPE_PLACEHOLDER_BG`, `TEA_TYPE_TEXT_COLORS`, `TEA_TYPE_ORIGINS` 전부 반영
- CSV 테이스팅 노트 기반 `teas`/`sellers` DB 시드 스크립트 추가 (`seed-teas-from-csv.js`)
- CSV 테이스팅 노트 기반 `notes`/`note_axis_value` DB 시드 스크립트 추가 (`seed-notes-from-csv.js`)

## Test plan
- [ ] 차 등록/수정 페이지에서 차종 드롭다운 확인 (청차/우롱차, 흑차/보이차 표시)
- [ ] 차종 배지 색상 정상 렌더링 확인
- [ ] 시드 스크립트 실행 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CSV 형식 파일에서 차 정보(종류, 가격, 년도), 판매처, 사용자의 시음 노트와 평가 점수를 데이터베이스로 직접 일괄 입력할 수 있는 스크립트 도구가 새로 추가되었습니다.

* **UI 업데이트**
  * 차 종류 분류 체계가 개편되었습니다. 기존의 8가지 분류에서 7가지로 간소화되었으며, 청차와 우롱차는 '청차/우롱차'로 통합되고, 흑차와 보이차는 '흑차/보이차'로 통합됩니다. 변경된 카테고리는 모든 차 정보 표시 화면에 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->