### PR TITLE
fix: 카카오 로그인 시 사용자 커스텀 이름 덮어쓰기 방지

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -157,10 +157,6 @@ export class UsersService {
       if (user.bannedAt) {
         throw new UnauthorizedException('정지된 계정입니다.');
       }
-      if (name && user.name !== name) {
-        user.name = name;
-        await this.usersRepository.save(user);
-      }
       if (email) {
         await this.addEmailAuthIfNotExists(user.id, email);
       }


### PR DESCRIPTION
## Summary
- 카카오 로그인할 때마다 카카오 프로필 닉네임으로 `user.name`을 덮어쓰는 로직 제거
- 사용자가 프로필에서 변경한 이름이 재로그인 후에도 유지됨
- 신규 사용자는 기존대로 카카오 닉네임으로 최초 생성

## Test plan
- [ ] 카카오 로그인 후 프로필에서 이름 변경
- [ ] 재로그인 후 변경한 이름이 유지되는지 확인
- [ ] 신규 카카오 계정으로 로그인 시 카카오 닉네임이 정상 설정되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)