### PR TITLE
feat: 차담 게시판 카테고리 세분화 + 그룹 라벨 표시

### DIFF
--- a/backend/migrations/1773154262603-ExpandPostCategories.ts
+++ b/backend/migrations/1773154262603-ExpandPostCategories.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ExpandPostCategories1773154262603 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // 1. enum에 새 값 추가 + tool → discussion 이름 변경
+        await queryRunner.query(`
+            ALTER TABLE posts
+            MODIFY COLUMN category ENUM(
+                'brewing_question',
+                'recommendation',
+                'tool',
+                'discussion',
+                'tea_review',
+                'tool_review',
+                'tea_room_review',
+                'announcement',
+                'bug_report'
+            ) NOT NULL
+        `);
+
+        // 2. 기존 'tool' 데이터를 'discussion'으로 마이그레이션
+        await queryRunner.query(`
+            UPDATE posts SET category = 'discussion' WHERE category = 'tool'
+        `);
+
+        // 3. 'tool' 값을 enum에서 제거
+        await queryRunner.query(`
+            ALTER TABLE posts
+            MODIFY COLUMN category ENUM(
+                'brewing_question',
+                'recommendation',
+                'discussion',
+                'tea_review',
+                'tool_review',
+                'tea_room_review',
+                'announcement',
+                'bug_report'
+            ) NOT NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // 1. 'tool' 값을 다시 enum에 추가
+        await queryRunner.query(`
+            ALTER TABLE posts
+            MODIFY COLUMN category ENUM(
+                'brewing_question',
+                'recommendation',
+                'tool',
+                'discussion',
+                'tea_review',
+                'tool_review',
+                'tea_room_review',
+                'announcement',
+                'bug_report'
+            ) NOT NULL
+        `);
+
+        // 2. 'discussion' → 'tool'로 복원
+        await queryRunner.query(`
+            UPDATE posts SET category = 'tool' WHERE category = 'discussion'
+        `);
+
+        // 3. 새 카테고리 제거
+        await queryRunner.query(`
+            ALTER TABLE posts
+            MODIFY COLUMN category ENUM(
+                'brewing_question',
+                'recommendation',
+                'tool',
+                'tea_room_review',
+                'announcement',
+                'bug_report'
+            ) NOT NULL
+        `);
+    }
+
+}

--- a/backend/src/posts/entities/post.entity.ts
+++ b/backend/src/posts/entities/post.entity.ts
@@ -16,7 +16,9 @@ import { PostImage } from './post-image.entity';
 export enum PostCategory {
   BREWING_QUESTION = 'brewing_question',
   RECOMMENDATION = 'recommendation',
-  TOOL = 'tool',
+  DISCUSSION = 'discussion',
+  TEA_REVIEW = 'tea_review',
+  TOOL_REVIEW = 'tool_review',
   TEA_ROOM_REVIEW = 'tea_room_review',
   ANNOUNCEMENT = 'announcement',
   BUG_REPORT = 'bug_report',

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,6 +1,6 @@
 import React, { type FC, useState, memo } from 'react';
 import { Heart, Bookmark, Loader2, MessageCircle, Eye, Megaphone, Pin, Image as ImageIcon, Shield } from 'lucide-react';
-import { Post, POST_CATEGORY_LABELS } from '../types';
+import { Post, POST_CATEGORY_LABELS, POST_CATEGORY_GROUP_LABELS } from '../types';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
@@ -99,6 +99,10 @@ const PostCardComponent: FC<PostCardProps> = ({ post, commentCount, onBookmarkTo
                   공지
                 </span>
               )}
+              <span className="text-xs text-muted-foreground font-medium">
+                {POST_CATEGORY_GROUP_LABELS[post.category]}
+              </span>
+              <span className="text-[10px] text-muted-foreground/60">·</span>
               <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary font-medium">
                 {POST_CATEGORY_LABELS[post.category]}
               </span>

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -30,9 +30,9 @@ const GROUPS: Array<{ key: GroupKey; label: string; categories: PostCategory[] }
   {
     key: 'qna',
     label: '질문·토론',
-    categories: ['brewing_question', 'recommendation', 'tool'],
+    categories: ['brewing_question', 'recommendation', 'discussion'],
   },
-  { key: 'review', label: '리뷰', categories: ['tea_room_review'] },
+  { key: 'review', label: '리뷰', categories: ['tea_review', 'tool_review', 'tea_room_review'] },
   { key: 'announcement', label: '공지', categories: ['announcement'] },
   { key: 'report', label: '제보', categories: ['bug_report'] },
 ];

--- a/src/pages/EditPost.tsx
+++ b/src/pages/EditPost.tsx
@@ -25,13 +25,17 @@ const WRITE_GROUPS: Array<{
     categories: [
       { value: 'brewing_question', label: POST_CATEGORY_LABELS.brewing_question, hint: '우림법, 온도, 시간 등' },
       { value: 'recommendation', label: POST_CATEGORY_LABELS.recommendation, hint: '차 추천 요청' },
-      { value: 'tool', label: POST_CATEGORY_LABELS.tool, hint: '도구·기구 관련' },
+      { value: 'discussion', label: POST_CATEGORY_LABELS.discussion, hint: '자유 주제 토론' },
     ],
   },
   {
     key: 'review',
     label: '리뷰',
-    categories: [{ value: 'tea_room_review', label: POST_CATEGORY_LABELS.tea_room_review }],
+    categories: [
+      { value: 'tea_review', label: POST_CATEGORY_LABELS.tea_review, hint: '차 시음 후기' },
+      { value: 'tool_review', label: POST_CATEGORY_LABELS.tool_review, hint: '다기·도구 후기' },
+      { value: 'tea_room_review', label: POST_CATEGORY_LABELS.tea_room_review, hint: '찻집·카페 방문기' },
+    ],
   },
   {
     key: 'announcement',

--- a/src/pages/NewPost.tsx
+++ b/src/pages/NewPost.tsx
@@ -25,13 +25,17 @@ const WRITE_GROUPS: Array<{
     categories: [
       { value: 'brewing_question', label: POST_CATEGORY_LABELS.brewing_question, hint: '우림법, 온도, 시간 등' },
       { value: 'recommendation', label: POST_CATEGORY_LABELS.recommendation, hint: '차 추천 요청' },
-      { value: 'tool', label: POST_CATEGORY_LABELS.tool, hint: '도구·기구 관련' },
+      { value: 'discussion', label: POST_CATEGORY_LABELS.discussion, hint: '자유 주제 토론' },
     ],
   },
   {
     key: 'review',
     label: '리뷰',
-    categories: [{ value: 'tea_room_review', label: POST_CATEGORY_LABELS.tea_room_review }],
+    categories: [
+      { value: 'tea_review', label: POST_CATEGORY_LABELS.tea_review, hint: '차 시음 후기' },
+      { value: 'tool_review', label: POST_CATEGORY_LABELS.tool_review, hint: '다기·도구 후기' },
+      { value: 'tea_room_review', label: POST_CATEGORY_LABELS.tea_room_review, hint: '찻집·카페 방문기' },
+    ],
   },
   {
     key: 'announcement',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,7 +172,9 @@ export interface CellarItem {
 export type PostCategory =
   | 'brewing_question'
   | 'recommendation'
-  | 'tool'
+  | 'discussion'
+  | 'tea_review'
+  | 'tool_review'
   | 'tea_room_review'
   | 'announcement'
   | 'bug_report';
@@ -180,10 +182,24 @@ export type PostCategory =
 export const POST_CATEGORY_LABELS: Record<PostCategory, string> = {
   brewing_question: '우림 질문',
   recommendation: '맞춤 추천',
-  tool: '도구',
+  discussion: '자유 토론',
+  tea_review: '차 리뷰',
+  tool_review: '차도구 리뷰',
   tea_room_review: '찻집 후기',
   announcement: '공지사항',
   bug_report: '버그/운영제보',
+};
+
+/** 카테고리 → 그룹 라벨 매핑 */
+export const POST_CATEGORY_GROUP_LABELS: Record<PostCategory, string> = {
+  brewing_question: '질문·토론',
+  recommendation: '질문·토론',
+  discussion: '질문·토론',
+  tea_review: '리뷰',
+  tool_review: '리뷰',
+  tea_room_review: '리뷰',
+  announcement: '공지',
+  bug_report: '제보',
 };
 
 export interface PostImageItem {


### PR DESCRIPTION
## Summary
- `tool` → `discussion`(자유 토론)으로 변경
- 리뷰 그룹에 `tea_review`(차 리뷰), `tool_review`(차도구 리뷰) 추가
- PostCard에 그룹 라벨(질문·토론, 리뷰 등) 세부 카테고리 앞에 표시
- TypeORM 마이그레이션으로 DB enum 변경 + 기존 `tool` 데이터 → `discussion` 마이그레이션

## Test plan
- [ ] 새 글 작성 시 확장된 카테고리 선택 가능 확인
- [ ] 게시글 목록에서 그룹 라벨 + 세부 카테고리 표시 확인
- [ ] 기존 'tool' 카테고리 게시글이 'discussion'으로 정상 표시 확인
- [ ] 마이그레이션 up/down 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 포스트 카테고리에 새로운 리뷰 옵션 추가: 차 리뷰, 도구 리뷰
  * 질문·토론 카테고리에 "토론" 옵션 추가

* **Chores**
  * 포스트 카테고리 구조 업데이트 및 데이터 마이그레이션
  * 포스트 작성 및 커뮤니티 필터링 옵션 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->