### PR TITLE
feat: #206 전체 색상 테마를 난색(Warm Color) 계열로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,11 @@ your-key.pem
 # SQL Tools session files
 *.session.sql
 chalog-s3-user_accessKeys.csv
+.omc/project-memory.json
+.omc/sessions/296f6087-48ce-477d-96e0-a1d769650316.json
+.omc/sessions/c1ed7131-abb4-41bc-8c17-dbf3a7642b91.json
+.omc/state/hud-state.json
+.omc/state/hud-stdin-cache.json
+.omc/state/idle-notif-cooldown.json
+.omc/state/mission-state.json
+.omc/state/checkpoints/checkpoint-2026-03-11T13-03-44-521Z.json

--- a/src/components/AxisStarRow.tsx
+++ b/src/components/AxisStarRow.tsx
@@ -111,7 +111,7 @@ export const AxisStarRow: FC<AxisStarRowProps> = ({
                   }}
                   className={cn(
                     'relative p-0.5 rounded transition-all duration-150',
-                    'focus:outline-none focus:ring-2 focus:ring-green-500/50 focus:ring-offset-1',
+                    'focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:ring-offset-1',
                     'hover:scale-110 active:scale-95 cursor-pointer'
                   )}
                   aria-label={`${starValue - 0.5}~${starValue}점`}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -156,7 +156,7 @@ const PostCardComponent: FC<PostCardProps> = ({ post, commentCount, onBookmarkTo
                   className={cn(
                     'truncate hover:underline text-left',
                     post.user?.role === 'admin'
-                      ? 'font-semibold text-green-600 hover:text-green-700'
+                      ? 'font-semibold text-amber-700 hover:text-amber-800'
                       : 'font-medium hover:text-foreground',
                   )}
                   aria-label="작성자 프로필 보기"
@@ -164,7 +164,7 @@ const PostCardComponent: FC<PostCardProps> = ({ post, commentCount, onBookmarkTo
                   {post.user?.name}
                 </button>
                 {post.user?.role === 'admin' && (
-                  <Shield className="w-3.5 h-3.5 text-green-600 shrink-0" aria-label="관리자" />
+                  <Shield className="w-3.5 h-3.5 text-amber-700 shrink-0" aria-label="관리자" />
                 )}
               </span>
             )}

--- a/src/components/RatingVisualization.tsx
+++ b/src/components/RatingVisualization.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from 'recharts';
 
-const CHART_COLOR = 'rgb(34 197 94)'; // green-500 (차록 rating)
+const CHART_COLOR = 'rgb(217 119 6)'; // amber-500 (rating)
 const GRID_COLOR = 'rgb(229 231 235)'; // gray-200
 import {
   Popover,

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -33,8 +33,8 @@ function NotificationIcon({ type }: { type: Notification['type'] }) {
     );
   }
   return (
-    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-green-100">
-      <UserPlus className="w-4 h-4 text-green-600" />
+    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-amber-100">
+      <UserPlus className="w-4 h-4 text-amber-700" />
     </div>
   );
 }

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -218,7 +218,7 @@ export function PostDetail() {
                 className={cn(
                   'hover:underline',
                   post.user?.role === 'admin'
-                    ? 'font-semibold text-green-600 hover:text-green-700'
+                    ? 'font-semibold text-amber-700 hover:text-amber-800'
                     : 'font-medium text-foreground',
                 )}
                 aria-label="작성자 프로필 보기"
@@ -226,7 +226,7 @@ export function PostDetail() {
                 {post.user?.name}
               </button>
               {post.user?.role === 'admin' && (
-                <Shield className="w-3.5 h-3.5 text-green-600 shrink-0" aria-label="관리자" />
+                <Shield className="w-3.5 h-3.5 text-amber-700 shrink-0" aria-label="관리자" />
               )}
             </span>
           )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,9 +16,9 @@
   --card-foreground: oklch(0.18 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.18 0 0);
-  --primary: #1db93c;
+  --primary: #b45309;
   --primary-foreground: #ffffff;
-  --secondary: oklch(0.97 0.005 150);
+  --secondary: oklch(0.97 0.01 80);
   --secondary-foreground: oklch(0.2 0 0);
   --muted: #f0f1f3;
   --muted-foreground: #6b7280;
@@ -33,8 +33,8 @@
   --font-weight-medium: 500;
   --font-weight-normal: 400;
   --ring: oklch(0.708 0 0);
-  --rating: #22c55e;
-  --success: oklch(0.55 0.15 160);
+  --rating: #d97706;
+  --success: oklch(0.55 0.12 50);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -43,7 +43,7 @@
   --radius: 0.75rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: #1db93c;
+  --sidebar-primary: #b45309;
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
@@ -62,7 +62,7 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.145 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: #1db93c;
+  --primary: #d97706;
   --primary-foreground: #ffffff;
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
@@ -75,8 +75,8 @@
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);
-  --rating: #22c55e;
-  --success: oklch(0.6 0.15 160);
+  --rating: #f59e0b;
+  --success: oklch(0.6 0.12 50);
   --font-weight-medium: 500;
   --font-weight-normal: 400;
   --chart-1: oklch(0.488 0.243 264.376);
@@ -86,7 +86,7 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: #1db93c;
+  --sidebar-primary: #d97706;
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ import path from 'path';
         name: '차멍 - 차 기록 앱',
         short_name: '차멍',
         description: '나만의 차 기록과 발견을 위한 앱',
-        theme_color: '#2d5a27',
+        theme_color: '#92400e',
         background_color: '#ffffff',
         display: 'standalone',
         orientation: 'portrait',


### PR DESCRIPTION
## Summary

- Primary 색상을 녹색(`#1db93c`)에서 amber-700(`#b45309`)으로 변경 (다크모드: `#d97706`)
- Rating/별점 색상을 `#22c55e`에서 amber-500(`#d97706`)으로 변경 (다크모드: `#f59e0b`)
- `success`, `secondary`, `sidebar-primary` warm tone으로 통일
- 컴포넌트 hardcoded `green-*` 클래스 → `amber-*`로 교체 (PostCard, PostDetail, AxisStarRow, RatingVisualization, Notifications)
- PWA `theme_color` `#2d5a27` → `#92400e`

Closes #206

## Test plan

- [ ] 라이트모드 Primary(amber-700), BottomNav 활성 탭, 슬라이더, 별점 아이콘 amber 색상 확인
- [ ] 다크모드 Primary(amber-500), 별점(amber-400) 가독성 확인
- [ ] 관리자 배지(Shield 아이콘) amber 색상 확인
- [ ] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
* 애플리케이션의 색상 테마를 녹색에서 황색/주황색으로 변경했습니다. 평가 컨트롤, 관리자 인디케이터, 알림 아이콘, 차트 및 사이드바 색상이 새로운 색상 팔레트로 업데이트되었습니다.
* 밝은 테마와 어두운 테마 모두에서 기본 색상, 보조 색상, 성공 표시 색상이 통일된 새로운 색상으로 적용되었습니다.

## 기타
* 개발 환경 설정 및 무시 파일을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->