### PR TITLE
fix: #192 차록 수정/삭제/비공개 기능 동작 안함

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
                   },
                   "devDependencies": {
                         "@tailwindcss/vite": "^4.1.18",
+                        "@testing-library/dom": "^10.4.1",
                         "@testing-library/jest-dom": "^6.9.1",
                         "@testing-library/react": "^16.3.2",
                         "@testing-library/user-event": "^14.6.1",
@@ -3054,7 +3055,7 @@
                   "version": "0.8.1",
                   "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
                   "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "dependencies": {
                         "@jridgewell/trace-mapping": "0.3.9"
@@ -3067,7 +3068,7 @@
                   "version": "0.3.9",
                   "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
                   "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "dependencies": {
                         "@jridgewell/resolve-uri": "^3.0.3",
@@ -3710,152 +3711,6 @@
                         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
                   }
             },
-            "node_modules/@eslint/config-array": {
-                  "version": "0.21.2",
-                  "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-                  "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "dependencies": {
-                        "@eslint/object-schema": "^2.1.7",
-                        "debug": "^4.3.1",
-                        "minimatch": "^3.1.5"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  }
-            },
-            "node_modules/@eslint/config-helpers": {
-                  "version": "0.4.2",
-                  "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-                  "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "dependencies": {
-                        "@eslint/core": "^0.17.0"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  }
-            },
-            "node_modules/@eslint/core": {
-                  "version": "0.17.0",
-                  "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-                  "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "dependencies": {
-                        "@types/json-schema": "^7.0.15"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  }
-            },
-            "node_modules/@eslint/eslintrc": {
-                  "version": "3.3.5",
-                  "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-                  "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "ajv": "^6.14.0",
-                        "debug": "^4.3.2",
-                        "espree": "^10.0.1",
-                        "globals": "^14.0.0",
-                        "ignore": "^5.2.0",
-                        "import-fresh": "^3.2.1",
-                        "js-yaml": "^4.1.1",
-                        "minimatch": "^3.1.5",
-                        "strip-json-comments": "^3.1.1"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  },
-                  "funding": {
-                        "url": "https://opencollective.com/eslint"
-                  }
-            },
-            "node_modules/@eslint/eslintrc/node_modules/ajv": {
-                  "version": "6.14.0",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-                  "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                  },
-                  "funding": {
-                        "type": "github",
-                        "url": "https://github.com/sponsors/epoberezkin"
-                  }
-            },
-            "node_modules/@eslint/eslintrc/node_modules/ignore": {
-                  "version": "5.3.2",
-                  "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-                  "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": ">= 4"
-                  }
-            },
-            "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-                  "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                  "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true
-            },
-            "node_modules/@eslint/js": {
-                  "version": "9.39.4",
-                  "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-                  "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  },
-                  "funding": {
-                        "url": "https://eslint.org/donate"
-                  }
-            },
-            "node_modules/@eslint/object-schema": {
-                  "version": "2.1.7",
-                  "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-                  "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  }
-            },
-            "node_modules/@eslint/plugin-kit": {
-                  "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-                  "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "dependencies": {
-                        "@eslint/core": "^0.17.0",
-                        "levn": "^0.4.1"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  }
-            },
             "node_modules/@floating-ui/core": {
                   "version": "1.7.5",
                   "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -3893,62 +3748,6 @@
                   "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
                   "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
                   "license": "MIT"
-            },
-            "node_modules/@humanfs/core": {
-                  "version": "0.19.1",
-                  "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-                  "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=18.18.0"
-                  }
-            },
-            "node_modules/@humanfs/node": {
-                  "version": "0.16.7",
-                  "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-                  "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "dependencies": {
-                        "@humanfs/core": "^0.19.1",
-                        "@humanwhocodes/retry": "^0.4.0"
-                  },
-                  "engines": {
-                        "node": ">=18.18.0"
-                  }
-            },
-            "node_modules/@humanwhocodes/module-importer": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-                  "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=12.22"
-                  },
-                  "funding": {
-                        "type": "github",
-                        "url": "https://github.com/sponsors/nzakas"
-                  }
-            },
-            "node_modules/@humanwhocodes/retry": {
-                  "version": "0.4.3",
-                  "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-                  "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=18.18"
-                  },
-                  "funding": {
-                        "type": "github",
-                        "url": "https://github.com/sponsors/nzakas"
-                  }
             },
             "node_modules/@img/colour": {
                   "version": "1.1.0",
@@ -5401,7 +5200,7 @@
                   "version": "3.1.2",
                   "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
                   "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "engines": {
                         "node": ">=6.0.0"
@@ -5422,7 +5221,7 @@
                   "version": "1.5.5",
                   "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
                   "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/@jridgewell/trace-mapping": {
@@ -9242,7 +9041,6 @@
                   "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
                   "dev": true,
                   "license": "MIT",
-                  "peer": true,
                   "dependencies": {
                         "@babel/code-frame": "^7.10.4",
                         "@babel/runtime": "^7.12.5",
@@ -9353,28 +9151,28 @@
                   "version": "1.0.12",
                   "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
                   "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/@tsconfig/node12": {
                   "version": "1.0.11",
                   "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
                   "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/@tsconfig/node14": {
                   "version": "1.0.3",
                   "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
                   "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/@tsconfig/node16": {
                   "version": "1.0.4",
                   "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
                   "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/@tybys/wasm-util": {
@@ -9393,8 +9191,7 @@
                   "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
                   "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
                   "dev": true,
-                  "license": "MIT",
-                  "peer": true
+                  "license": "MIT"
             },
             "node_modules/@types/babel__core": {
                   "version": "7.20.5",
@@ -9819,6 +9616,7 @@
                   "version": "19.2.14",
                   "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
                   "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+                  "dev": true,
                   "license": "MIT",
                   "dependencies": {
                         "csstype": "^3.2.2"
@@ -9828,7 +9626,7 @@
                   "version": "19.2.3",
                   "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
                   "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "peerDependencies": {
                         "@types/react": "^19.2.0"
@@ -10795,7 +10593,7 @@
                   "version": "8.16.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
                   "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "bin": {
                         "acorn": "bin/acorn"
@@ -10817,22 +10615,11 @@
                         "acorn": "^8.14.0"
                   }
             },
-            "node_modules/acorn-jsx": {
-                  "version": "5.3.2",
-                  "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-                  "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "peerDependencies": {
-                        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-                  }
-            },
             "node_modules/acorn-walk": {
                   "version": "8.3.5",
                   "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
                   "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "dependencies": {
                         "acorn": "^8.11.0"
@@ -11002,7 +10789,7 @@
                   "version": "4.1.3",
                   "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
                   "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/argparse": {
@@ -12296,7 +12083,7 @@
                   "version": "1.1.1",
                   "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
                   "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/cross-spawn": {
@@ -12565,17 +12352,6 @@
                         "url": "https://github.com/sponsors/ljharb"
                   }
             },
-            "node_modules/date-fns": {
-                  "version": "3.6.0",
-                  "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-                  "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-                  "license": "MIT",
-                  "peer": true,
-                  "funding": {
-                        "type": "github",
-                        "url": "https://github.com/sponsors/kossnocorp"
-                  }
-            },
             "node_modules/dayjs": {
                   "version": "1.11.19",
                   "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -12648,14 +12424,6 @@
                   "engines": {
                         "node": ">=6"
                   }
-            },
-            "node_modules/deep-is": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-                  "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true
             },
             "node_modules/deepmerge": {
                   "version": "4.3.1",
@@ -12804,7 +12572,7 @@
                   "version": "4.0.4",
                   "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
                   "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "BSD-3-Clause",
                   "engines": {
                         "node": ">=0.3.1"
@@ -12815,8 +12583,7 @@
                   "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
                   "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
                   "dev": true,
-                  "license": "MIT",
-                  "peer": true
+                  "license": "MIT"
             },
             "node_modules/dom-helpers": {
                   "version": "5.2.1",
@@ -13212,67 +12979,6 @@
                         "node": ">=8"
                   }
             },
-            "node_modules/eslint": {
-                  "version": "9.39.4",
-                  "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-                  "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "@eslint-community/eslint-utils": "^4.8.0",
-                        "@eslint-community/regexpp": "^4.12.1",
-                        "@eslint/config-array": "^0.21.2",
-                        "@eslint/config-helpers": "^0.4.2",
-                        "@eslint/core": "^0.17.0",
-                        "@eslint/eslintrc": "^3.3.5",
-                        "@eslint/js": "9.39.4",
-                        "@eslint/plugin-kit": "^0.4.1",
-                        "@humanfs/node": "^0.16.6",
-                        "@humanwhocodes/module-importer": "^1.0.1",
-                        "@humanwhocodes/retry": "^0.4.2",
-                        "@types/estree": "^1.0.6",
-                        "ajv": "^6.14.0",
-                        "chalk": "^4.0.0",
-                        "cross-spawn": "^7.0.6",
-                        "debug": "^4.3.2",
-                        "escape-string-regexp": "^4.0.0",
-                        "eslint-scope": "^8.4.0",
-                        "eslint-visitor-keys": "^4.2.1",
-                        "espree": "^10.4.0",
-                        "esquery": "^1.5.0",
-                        "esutils": "^2.0.2",
-                        "fast-deep-equal": "^3.1.3",
-                        "file-entry-cache": "^8.0.0",
-                        "find-up": "^5.0.0",
-                        "glob-parent": "^6.0.2",
-                        "ignore": "^5.2.0",
-                        "imurmurhash": "^0.1.4",
-                        "is-glob": "^4.0.0",
-                        "json-stable-stringify-without-jsonify": "^1.0.1",
-                        "lodash.merge": "^4.6.2",
-                        "minimatch": "^3.1.5",
-                        "natural-compare": "^1.4.0",
-                        "optionator": "^0.9.3"
-                  },
-                  "bin": {
-                        "eslint": "bin/eslint.js"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  },
-                  "funding": {
-                        "url": "https://eslint.org/donate"
-                  },
-                  "peerDependencies": {
-                        "jiti": "*"
-                  },
-                  "peerDependenciesMeta": {
-                        "jiti": {
-                              "optional": true
-                        }
-                  }
-            },
             "node_modules/eslint-scope": {
                   "version": "5.1.1",
                   "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -13300,185 +13006,6 @@
                         "url": "https://opencollective.com/eslint"
                   }
             },
-            "node_modules/eslint/node_modules/ajv": {
-                  "version": "6.14.0",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-                  "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "fast-deep-equal": "^3.1.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
-                  },
-                  "funding": {
-                        "type": "github",
-                        "url": "https://github.com/sponsors/epoberezkin"
-                  }
-            },
-            "node_modules/eslint/node_modules/escape-string-regexp": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                  "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=10"
-                  },
-                  "funding": {
-                        "url": "https://github.com/sponsors/sindresorhus"
-                  }
-            },
-            "node_modules/eslint/node_modules/eslint-scope": {
-                  "version": "8.4.0",
-                  "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-                  "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-                  "dev": true,
-                  "license": "BSD-2-Clause",
-                  "peer": true,
-                  "dependencies": {
-                        "esrecurse": "^4.3.0",
-                        "estraverse": "^5.2.0"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  },
-                  "funding": {
-                        "url": "https://opencollective.com/eslint"
-                  }
-            },
-            "node_modules/eslint/node_modules/eslint-visitor-keys": {
-                  "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-                  "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  },
-                  "funding": {
-                        "url": "https://opencollective.com/eslint"
-                  }
-            },
-            "node_modules/eslint/node_modules/estraverse": {
-                  "version": "5.3.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                  "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                  "dev": true,
-                  "license": "BSD-2-Clause",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=4.0"
-                  }
-            },
-            "node_modules/eslint/node_modules/find-up": {
-                  "version": "5.0.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-                  "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "locate-path": "^6.0.0",
-                        "path-exists": "^4.0.0"
-                  },
-                  "engines": {
-                        "node": ">=10"
-                  },
-                  "funding": {
-                        "url": "https://github.com/sponsors/sindresorhus"
-                  }
-            },
-            "node_modules/eslint/node_modules/ignore": {
-                  "version": "5.3.2",
-                  "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-                  "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": ">= 4"
-                  }
-            },
-            "node_modules/eslint/node_modules/json-schema-traverse": {
-                  "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-                  "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true
-            },
-            "node_modules/eslint/node_modules/locate-path": {
-                  "version": "6.0.0",
-                  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-                  "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "p-locate": "^5.0.0"
-                  },
-                  "engines": {
-                        "node": ">=10"
-                  },
-                  "funding": {
-                        "url": "https://github.com/sponsors/sindresorhus"
-                  }
-            },
-            "node_modules/eslint/node_modules/p-locate": {
-                  "version": "5.0.0",
-                  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-                  "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "p-limit": "^3.0.2"
-                  },
-                  "engines": {
-                        "node": ">=10"
-                  },
-                  "funding": {
-                        "url": "https://github.com/sponsors/sindresorhus"
-                  }
-            },
-            "node_modules/espree": {
-                  "version": "10.4.0",
-                  "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-                  "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-                  "dev": true,
-                  "license": "BSD-2-Clause",
-                  "peer": true,
-                  "dependencies": {
-                        "acorn": "^8.15.0",
-                        "acorn-jsx": "^5.3.2",
-                        "eslint-visitor-keys": "^4.2.1"
-                  },
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  },
-                  "funding": {
-                        "url": "https://opencollective.com/eslint"
-                  }
-            },
-            "node_modules/espree/node_modules/eslint-visitor-keys": {
-                  "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-                  "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-                  "dev": true,
-                  "license": "Apache-2.0",
-                  "peer": true,
-                  "engines": {
-                        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-                  },
-                  "funding": {
-                        "url": "https://opencollective.com/eslint"
-                  }
-            },
             "node_modules/esprima": {
                   "version": "4.0.1",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -13491,31 +13018,6 @@
                   },
                   "engines": {
                         "node": ">=4"
-                  }
-            },
-            "node_modules/esquery": {
-                  "version": "1.7.0",
-                  "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-                  "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-                  "dev": true,
-                  "license": "BSD-3-Clause",
-                  "peer": true,
-                  "dependencies": {
-                        "estraverse": "^5.1.0"
-                  },
-                  "engines": {
-                        "node": ">=0.10"
-                  }
-            },
-            "node_modules/esquery/node_modules/estraverse": {
-                  "version": "5.3.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                  "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                  "dev": true,
-                  "license": "BSD-2-Clause",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=4.0"
                   }
             },
             "node_modules/esrecurse": {
@@ -13756,14 +13258,6 @@
                   "dev": true,
                   "license": "MIT"
             },
-            "node_modules/fast-levenshtein": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                  "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true
-            },
             "node_modules/fast-safe-stringify": {
                   "version": "2.1.1",
                   "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -13844,20 +13338,6 @@
                         "picomatch": {
                               "optional": true
                         }
-                  }
-            },
-            "node_modules/file-entry-cache": {
-                  "version": "8.0.0",
-                  "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-                  "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "flat-cache": "^4.0.0"
-                  },
-                  "engines": {
-                        "node": ">=16.0.0"
                   }
             },
             "node_modules/file-type": {
@@ -13958,40 +13438,6 @@
                   "engines": {
                         "node": ">=8"
                   }
-            },
-            "node_modules/flat-cache": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-                  "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "flatted": "^3.2.9",
-                        "keyv": "^4.5.4"
-                  },
-                  "engines": {
-                        "node": ">=16"
-                  }
-            },
-            "node_modules/flat-cache/node_modules/keyv": {
-                  "version": "4.5.4",
-                  "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-                  "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "json-buffer": "3.0.1"
-                  }
-            },
-            "node_modules/flatted": {
-                  "version": "3.4.1",
-                  "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-                  "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
-                  "dev": true,
-                  "license": "ISC",
-                  "peer": true
             },
             "node_modules/follow-redirects": {
                   "version": "1.15.11",
@@ -14379,20 +13825,6 @@
                         "url": "https://github.com/sponsors/isaacs"
                   }
             },
-            "node_modules/glob-parent": {
-                  "version": "6.0.2",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-                  "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-                  "dev": true,
-                  "license": "ISC",
-                  "peer": true,
-                  "dependencies": {
-                        "is-glob": "^4.0.3"
-                  },
-                  "engines": {
-                        "node": ">=10.13.0"
-                  }
-            },
             "node_modules/glob-to-regexp": {
                   "version": "0.4.1",
                   "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -14437,20 +13869,6 @@
                   },
                   "funding": {
                         "url": "https://github.com/sponsors/isaacs"
-                  }
-            },
-            "node_modules/globals": {
-                  "version": "14.0.0",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-                  "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=18"
-                  },
-                  "funding": {
-                        "url": "https://github.com/sponsors/sindresorhus"
                   }
             },
             "node_modules/globalthis": {
@@ -15106,17 +14524,6 @@
                         "url": "https://github.com/sponsors/wooorm"
                   }
             },
-            "node_modules/is-extglob": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                  "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=0.10.0"
-                  }
-            },
             "node_modules/is-finalizationregistry": {
                   "version": "1.1.1",
                   "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -15170,20 +14577,6 @@
                   },
                   "funding": {
                         "url": "https://github.com/sponsors/ljharb"
-                  }
-            },
-            "node_modules/is-glob": {
-                  "version": "4.0.3",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-                  "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "is-extglob": "^2.1.1"
-                  },
-                  "engines": {
-                        "node": ">=0.10.0"
                   }
             },
             "node_modules/is-hexadecimal": {
@@ -16625,14 +16018,6 @@
                         "node": ">=6"
                   }
             },
-            "node_modules/json-buffer": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-                  "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true
-            },
             "node_modules/json-parse-even-better-errors": {
                   "version": "2.3.1",
                   "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -16653,14 +16038,6 @@
                   "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
                   "dev": true,
                   "license": "MIT"
-            },
-            "node_modules/json-stable-stringify-without-jsonify": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-                  "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true
             },
             "node_modules/json5": {
                   "version": "2.2.3",
@@ -16781,21 +16158,6 @@
                   "license": "MIT",
                   "engines": {
                         "node": ">=6"
-                  }
-            },
-            "node_modules/levn": {
-                  "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-                  "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "prelude-ls": "^1.2.1",
-                        "type-check": "~0.4.0"
-                  },
-                  "engines": {
-                        "node": ">= 0.8.0"
                   }
             },
             "node_modules/libphonenumber-js": {
@@ -17185,14 +16547,6 @@
                   "dev": true,
                   "license": "MIT"
             },
-            "node_modules/lodash.merge": {
-                  "version": "4.6.2",
-                  "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-                  "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true
-            },
             "node_modules/lodash.once": {
                   "version": "4.1.1",
                   "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -17307,7 +16661,6 @@
                   "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
                   "dev": true,
                   "license": "MIT",
-                  "peer": true,
                   "bin": {
                         "lz-string": "bin/bin.js"
                   }
@@ -17342,7 +16695,7 @@
                   "version": "1.3.6",
                   "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
                   "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "ISC"
             },
             "node_modules/makeerror": {
@@ -18753,25 +18106,6 @@
                         "url": "https://github.com/sponsors/sindresorhus"
                   }
             },
-            "node_modules/optionator": {
-                  "version": "0.9.4",
-                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-                  "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "deep-is": "^0.1.3",
-                        "fast-levenshtein": "^2.0.6",
-                        "levn": "^0.4.1",
-                        "prelude-ls": "^1.2.1",
-                        "type-check": "^0.4.0",
-                        "word-wrap": "^1.2.5"
-                  },
-                  "engines": {
-                        "node": ">= 0.8.0"
-                  }
-            },
             "node_modules/ora": {
                   "version": "5.4.1",
                   "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -19187,17 +18521,6 @@
                         "node": "^10 || ^12 || >=14"
                   }
             },
-            "node_modules/prelude-ls": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-                  "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": ">= 0.8.0"
-                  }
-            },
             "node_modules/pretty-bytes": {
                   "version": "6.1.1",
                   "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
@@ -19217,7 +18540,6 @@
                   "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
                   "dev": true,
                   "license": "MIT",
-                  "peer": true,
                   "dependencies": {
                         "ansi-regex": "^5.0.1",
                         "ansi-styles": "^5.0.0",
@@ -19425,8 +18747,7 @@
                   "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
                   "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
                   "dev": true,
-                  "license": "MIT",
-                  "peer": true
+                  "license": "MIT"
             },
             "node_modules/react-markdown": {
                   "version": "9.1.0",
@@ -21619,7 +20940,7 @@
                   "version": "10.9.2",
                   "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
                   "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "dependencies": {
                         "@cspotcode/source-map-support": "^0.8.0",
@@ -21705,20 +21026,6 @@
                   "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
                   "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
                   "license": "0BSD"
-            },
-            "node_modules/type-check": {
-                  "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-                  "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "dependencies": {
-                        "prelude-ls": "^1.2.1"
-                  },
-                  "engines": {
-                        "node": ">= 0.8.0"
-                  }
             },
             "node_modules/type-detect": {
                   "version": "4.0.8",
@@ -22037,7 +21344,7 @@
                   "version": "5.9.3",
                   "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
                   "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "Apache-2.0",
                   "bin": {
                         "tsc": "bin/tsc",
@@ -22444,7 +21751,7 @@
                   "version": "3.0.1",
                   "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
                   "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT"
             },
             "node_modules/v8-to-istanbul": {
@@ -23095,17 +22402,6 @@
                   },
                   "engines": {
                         "node": ">=8"
-                  }
-            },
-            "node_modules/word-wrap": {
-                  "version": "1.2.5",
-                  "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-                  "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-                  "dev": true,
-                  "license": "MIT",
-                  "peer": true,
-                  "engines": {
-                        "node": ">=0.10.0"
                   }
             },
             "node_modules/wordwrap": {
@@ -23763,7 +23059,7 @@
                   "version": "3.1.1",
                   "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
                   "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-                  "devOptional": true,
+                  "dev": true,
                   "license": "MIT",
                   "engines": {
                         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
       },
       "devDependencies": {
             "@tailwindcss/vite": "^4.1.18",
+            "@testing-library/dom": "^10.4.1",
             "@testing-library/jest-dom": "^6.9.1",
             "@testing-library/react": "^16.3.2",
             "@testing-library/user-event": "^14.6.1",

--- a/src/pages/EditNote.tsx
+++ b/src/pages/EditNote.tsx
@@ -27,7 +27,7 @@ export function EditNote() {
   const navigate = useNavigate();
   const { id } = useParams();
   const noteId = id ? parseInt(id, 10) : NaN;
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, isLoading: isAuthLoading } = useAuth();
   const [searchParams] = useSearchParams();
   const preselectedTeaId = searchParams.get('teaId');
   const teasRef = useRef<Tea[]>([]);
@@ -225,13 +225,14 @@ export function EditNote() {
       }
     };
 
+    if (isAuthLoading) return;
     if (isAuthenticated && user) {
       fetchNote();
     } else {
       toast.error('로그인이 필요합니다.');
       navigate('/login');
     }
-  }, [noteId, isAuthenticated, user, navigate]);
+  }, [noteId, isAuthenticated, user, isAuthLoading, navigate]);
 
   // 선택된 스키마 변경 시 축 정보 가져오기 (템플릿 변경 시에만, 초기 로드는 fetchNote에서 처리)
   const initialSchemaSet = useRef(false);

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -33,7 +33,7 @@ export function NoteDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const noteId = id ? parseInt(id, 10) : NaN;
-  const { user } = useAuth();
+  const { user, isLoading: isAuthLoading } = useAuth();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [note, setNote] = useState<Note | null>(null);
   const [tea, setTea] = useState<Tea | null>(null);
@@ -482,7 +482,7 @@ export function NoteDetail() {
         )}
 
         {/* 내 노트일 때만 노출되는 액션 */}
-        {isMyNote && (
+        {isMyNote && !isAuthLoading && (
           <section className="flex flex-col sm:flex-row gap-3">
             <Button
               variant="outline"
@@ -508,6 +508,7 @@ export function NoteDetail() {
               variant="outline"
               onClick={() => setShowDeleteDialog(true)}
               className="min-h-[44px] min-w-[44px] px-4"
+              aria-label="삭제"
             >
               <Trash2 className="w-5 h-5 text-red-600" />
             </Button>

--- a/src/pages/__tests__/NoteDetail.test.tsx
+++ b/src/pages/__tests__/NoteDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { NoteDetail } from '../NoteDetail';
@@ -15,6 +15,7 @@ vi.mock('../../lib/api', async () => {
     notesApi: {
       getById: vi.fn(),
       delete: vi.fn(),
+      update: vi.fn(),
     },
     teasApi: {
       ...(actual as any).teasApi,
@@ -34,6 +35,7 @@ vi.mock('../../lib/api', async () => {
 vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => ({
     user: { id: 1, name: '테스트 사용자', email: 'test@example.com' },
+    isLoading: false,
   }),
 }));
 
@@ -125,6 +127,99 @@ describe('NoteDetail - 이미지 가운데 정렬', () => {
       const authorName = screen.getByText('테스트 사용자');
       expect(authorName).toHaveClass('hover:text-primary', 'cursor-pointer');
     });
+  });
+});
+
+describe('NoteDetail - 수정/삭제/비공개 기능', () => {
+  beforeEach(() => {
+    vi.mocked(notesApi.getById).mockResolvedValue(mockNote);
+    vi.mocked(notesApi.delete).mockResolvedValue(undefined as any);
+    vi.mocked(notesApi.update).mockResolvedValue({ ...mockNote, isPublic: false } as any);
+    mockNavigate.mockClear();
+  });
+
+  it('수정 버튼 클릭 시 편집 페이지로 이동해야 함', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <NoteDetail />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('수정')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('수정'));
+    expect(mockNavigate).toHaveBeenCalledWith('/note/1/edit');
+  });
+
+  it('비공개 전환 버튼 클릭 시 notesApi.update가 호출되어야 함', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <NoteDetail />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('비공개로 전환')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('비공개로 전환'));
+
+    await waitFor(() => {
+      expect(notesApi.update).toHaveBeenCalledWith(1, { isPublic: false });
+    });
+  });
+
+  it('삭제 버튼 클릭 시 AlertDialog가 열리고, 확인 시 notesApi.delete가 호출되어야 함', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <NoteDetail />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('수정')).toBeInTheDocument();
+    });
+
+    // 삭제 아이콘 버튼 클릭 (Trash2 아이콘 포함 버튼)
+    const deleteButton = screen.getByRole('button', { name: /삭제/i });
+    await user.click(deleteButton);
+
+    // AlertDialog 열림 확인
+    await waitFor(() => {
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    });
+
+    // 다이얼로그 내부의 삭제 확인 버튼 클릭
+    const dialog = screen.getByRole('alertdialog');
+    const confirmButton = within(dialog).getByRole('button', { name: '삭제' });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(notesApi.delete).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('내 노트가 아닐 때 수정/삭제/비공개 버튼이 노출되지 않아야 함', async () => {
+    const otherUserNote: Note = { ...mockNote, userId: 999 };
+    vi.mocked(notesApi.getById).mockResolvedValue(otherUserNote);
+
+    render(
+      <MemoryRouter>
+        <NoteDetail />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('테스트 사용자')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('수정')).not.toBeInTheDocument();
+    expect(screen.queryByText('비공개로 전환')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

- **EditNote.tsx**: `isAuthLoading` guard 추가 — auth 초기화 전 `/login` 리다이렉트 방지 (race condition 수정)
- **NoteDetail.tsx**: `isAuthLoading` 중 수정/삭제/비공개 버튼 숨김, 삭제 버튼 `aria-label` 추가
- **NoteDetail.test.tsx**: 수정/삭제/비공개/권한 테스트 케이스 4개 추가

## Root Cause

`AuthContext`가 localStorage에서 인증 상태를 복원하기 전(`isLoading=true`) `EditNote.tsx`의 useEffect가 `isAuthenticated=false`를 보고 즉시 `/login`으로 리다이렉트하는 경쟁 조건.

## Test plan

- [x] `npm run test:run` — 8개 테스트 모두 통과
- [x] `npm run build` — 빌드 성공
- [ ] 로그인 후 내 차록 상세에서 수정 버튼 클릭 → EditNote 정상 이동
- [ ] 비공개 전환 버튼 클릭 → 버튼 텍스트 변경
- [ ] 삭제 버튼 → 다이얼로그 → 삭제 후 이전 페이지 이동

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 로딩 상태가 완료될 때까지 노트 데이터 로드를 지연시켜 안정성 개선
  * "내 노트" 작업 섹션이 인증 로딩 완료 후 표시되도록 개선

* **접근성 개선**
  * 삭제 버튼에 접근성 라벨 추가

* **테스트**
  * 편집 네비게이션, 공개/비공개 토글, 삭제 기능, 접근 제어에 대한 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->