### PR TITLE
feat: #216 아이디(이메일) 찾기 기능 구현

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import { KakaoLoginDto } from './dto/kakao-login.dto';
 import { GoogleLoginDto } from './dto/google-login.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { FindEmailDto } from './dto/find-email.dto';
 import { AuthGuard } from '@nestjs/passport';
 
 @Controller('auth')
@@ -100,5 +101,17 @@ export class AuthController {
   async resetPassword(@Body() dto: ResetPasswordDto): Promise<{ message: string }> {
     await this.authService.resetPassword(dto.token, dto.newPassword);
     return { message: '비밀번호가 성공적으로 변경되었습니다.' };
+  }
+
+  @Throttle({ default: { limit: 5, ttl: 600000 } })
+  @Post('find-email')
+  async findEmail(@Body() dto: FindEmailDto): Promise<{ maskedEmail: string | null; message: string }> {
+    const result = await this.authService.findEmail(dto.name);
+    return {
+      ...result,
+      message: result.maskedEmail
+        ? '일치하는 계정을 찾았습니다.'
+        : '일치하는 계정이 없습니다.',
+    };
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -213,6 +213,23 @@ export class AuthService {
     await this.mailService.sendPasswordResetEmail(email, resetUrl);
   }
 
+  async findEmail(name: string): Promise<{ maskedEmail: string | null }> {
+    const user = await this.usersService.findByName(name);
+    if (!user) return { maskedEmail: null };
+
+    const auth = await this.userAuthRepository.findOne({
+      where: { userId: user.id, provider: AuthProvider.EMAIL },
+    });
+    if (!auth) return { maskedEmail: null };
+
+    const email = auth.providerId;
+    const [local, domain] = email.split('@');
+    const masked = local.length <= 2
+      ? local[0] + '***'
+      : local.slice(0, 2) + '***';
+    return { maskedEmail: `${masked}@${domain}` };
+  }
+
   async resetPassword(token: string, newPassword: string): Promise<void> {
     const tokenHash = createHash('sha256').update(token).digest('hex');
 

--- a/backend/src/auth/dto/find-email.dto.ts
+++ b/backend/src/auth/dto/find-email.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class FindEmailDto {
+  @IsString()
+  @MinLength(1, { message: '이름을 입력해주세요.' })
+  name: string;
+}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -87,6 +87,10 @@ export class UsersService {
     return user;
   }
 
+  async findByName(name: string): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { name } });
+  }
+
   async findByEmail(email: string): Promise<User | null> {
     const auth = await this.authRepository.findOne({
       where: { provider: AuthProvider.EMAIL, providerId: email },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ const EditPost = lazy(() => import('./pages/EditPost').then((m) => ({ default: m
 const Register = lazy(() => import('./pages/Register').then((m) => ({ default: m.Register })));
 const ForgotPassword = lazy(() => import('./pages/ForgotPassword').then((m) => ({ default: m.ForgotPassword })));
 const ResetPassword = lazy(() => import('./pages/ResetPassword').then((m) => ({ default: m.ResetPassword })));
+const FindEmail = lazy(() => import('./pages/FindEmail').then((m) => ({ default: m.FindEmail })));
 const Onboarding = lazy(() => import('./pages/Onboarding').then((m) => ({ default: m.Onboarding })));
 const TagDetail = lazy(() => import('./pages/TagDetail').then((m) => ({ default: m.TagDetail })));
 const ShopDetail = lazy(() => import('./pages/ShopDetail').then((m) => ({ default: m.ShopDetail })));
@@ -129,6 +130,7 @@ function FloatingActionButtonSwitcher() {
     location.pathname === '/onboarding' ||
     location.pathname === '/forgot-password' ||
     location.pathname === '/reset-password' ||
+    location.pathname === '/find-email' ||
     location.pathname.startsWith('/admin');
   
   const override = floatingActionRouteOverrides[location.pathname];
@@ -155,7 +157,7 @@ function FloatingActionButtonSwitcher() {
 function OnboardingRouteGuard({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const { user, isLoading, hasCompletedOnboarding, isOnboardingLoading } = useAuth();
-  const publicPaths = ['/login', '/register', '/forgot-password', '/reset-password', '/onboarding'];
+  const publicPaths = ['/login', '/register', '/forgot-password', '/reset-password', '/onboarding', '/find-email'];
 
   if (isLoading || isOnboardingLoading) {
     return null;
@@ -255,6 +257,7 @@ function AppContent() {
                 <Route path="/register" element={<Register />} />
                 <Route path="/forgot-password" element={<ForgotPassword />} />
                 <Route path="/reset-password" element={<ResetPassword />} />
+                <Route path="/find-email" element={<FindEmail />} />
                 <Route path="/onboarding" element={<Onboarding />} />
                 <Route path="/admin/*" element={<Navigate to="/admin" replace />} />
                 <Route path="/search" element={<Navigate to="/sasaek" replace />} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1121,6 +1121,8 @@ export const authApi = {
     apiClient.post<{ message: string }>('/auth/forgot-password', { email }),
   resetPassword: (token: string, newPassword: string) =>
     apiClient.post<{ message: string }>('/auth/reset-password', { token, newPassword }),
+  findEmail: (name: string) =>
+    apiClient.post<{ maskedEmail: string | null; message: string }>('/auth/find-email', { name }),
 };
 
 export const teasApi = {

--- a/src/pages/FindEmail.tsx
+++ b/src/pages/FindEmail.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { User, Loader2, ArrowLeft } from 'lucide-react';
+import { Header } from '../components/Header';
+import { Input } from '../components/ui/input';
+import { Button } from '../components/ui/button';
+import { Label } from '../components/ui/label';
+import { authApi } from '../lib/api';
+import { toast } from 'sonner';
+
+export function FindEmail() {
+  const [name, setName] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [result, setResult] = useState<{ maskedEmail: string | null; message: string } | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) {
+      toast.error('이름을 입력해주세요.');
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const response = await authApi.findEmail(name.trim());
+      setResult(response);
+    } catch {
+      toast.error('아이디 찾기에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen">
+      <Header showBack title="아이디 찾기" showProfile />
+
+      <div className="p-4 sm:max-w-md sm:mx-auto">
+        <div className="bg-card rounded-lg p-6 space-y-6">
+          <div>
+            <h1 className="text-2xl font-bold mb-2">아이디 찾기</h1>
+            <p className="text-gray-600 text-sm">
+              가입 시 등록한 이름을 입력하시면 이메일을 안내해드립니다.
+            </p>
+          </div>
+
+          {result ? (
+            <div className="space-y-4">
+              {result.maskedEmail ? (
+                <div className="bg-emerald-50 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300 rounded-lg p-4 text-sm">
+                  <p className="font-medium mb-1">가입된 이메일을 찾았습니다</p>
+                  <p>
+                    가입된 이메일: <span className="font-semibold">{result.maskedEmail}</span>
+                  </p>
+                </div>
+              ) : (
+                <div className="bg-gray-50 dark:bg-gray-900/30 text-gray-600 dark:text-gray-400 rounded-lg p-4 text-sm">
+                  <p>{result.message}</p>
+                </div>
+              )}
+              <div className="flex flex-col gap-2">
+                <Link to="/login">
+                  <Button variant="outline" className="w-full">
+                    <ArrowLeft className="w-4 h-4 mr-2" />
+                    로그인으로 돌아가기
+                  </Button>
+                </Link>
+                <Link to="/forgot-password">
+                  <Button variant="ghost" className="w-full text-sm text-emerald-600">
+                    비밀번호 찾기
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">이름</Label>
+                <div className="relative">
+                  <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+                  <Input
+                    id="name"
+                    type="text"
+                    placeholder="가입 시 등록한 이름을 입력하세요"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="pl-10"
+                    disabled={isLoading}
+                  />
+                </div>
+              </div>
+
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    찾는 중...
+                  </>
+                ) : (
+                  '아이디 찾기'
+                )}
+              </Button>
+
+              <div className="text-center text-sm space-x-4">
+                <Link to="/login" className="text-emerald-600 hover:underline">
+                  로그인으로 돌아가기
+                </Link>
+                <span className="text-gray-400">·</span>
+                <Link to="/forgot-password" className="text-emerald-600 hover:underline">
+                  비밀번호 찾기
+                </Link>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -232,8 +232,12 @@ export function Login() {
               )}
             </Button>
 
-            <div className="text-right">
-              <Link to="/forgot-password" className="text-sm text-emerald-600 hover:underline">
+            <div className="flex justify-end gap-3 text-sm">
+              <Link to="/find-email" className="text-emerald-600 hover:underline">
+                아이디 찾기
+              </Link>
+              <span className="text-gray-400">·</span>
+              <Link to="/forgot-password" className="text-emerald-600 hover:underline">
                 비밀번호 찾기
               </Link>
             </div>


### PR DESCRIPTION
## Summary

- `POST /auth/find-email` 엔드포인트 추가 (Rate limit 5회/10분)
- 이름으로 이메일 조회 후 마스킹 처리 (`ch***@gmail.com`)
- 일치 계정 없을 시 안내 메시지 반환
- `/find-email` 페이지 신규 추가
- 로그인 페이지에 '아이디 찾기' 링크 추가

Closes #216

## Test plan

- [ ] 로그인 페이지에서 '아이디 찾기' 링크 표시 확인
- [ ] 이름 입력 후 마스킹된 이메일 표시 확인
- [ ] 존재하지 않는 이름 → "일치하는 계정이 없습니다." 표시 확인
- [ ] `npm run build` + `cd backend && npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)