### PR TITLE
feat: #215 전체 메뉴 접근성 개선 - BottomNav 더보기 탭 추가

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Home, Search, MessageSquare, FileText, Package, ChevronLeft, ChevronRight, Bell, Settings } from 'lucide-react';
+import { Home, Search, MessageSquare, FileText, Package, ChevronLeft, ChevronRight, Bell, Settings, Bookmark, Clock, EyeOff } from 'lucide-react';
 import { cn } from './ui/utils';
 import { useSidebar } from '../contexts/SidebarContext';
 import { ChaLogLogo } from './ChaLogLogo';
@@ -75,6 +75,47 @@ export function AppSidebar() {
           </Link>
         ))}
       </nav>
+
+      {/* 더보기: 숨겨진 페이지들 */}
+      <div className={cn('py-2 border-t border-sidebar-border overflow-hidden', isExpanded ? 'px-2' : 'px-1')}>
+        {isExpanded && <p className="text-xs text-sidebar-foreground/40 px-3 pb-1">더보기</p>}
+        {[
+          {
+            path: '/saved',
+            label: '저장함',
+            Icon: Bookmark,
+            active: location.pathname === '/saved',
+          },
+          {
+            path: '/sessions',
+            label: '시음 세션',
+            Icon: Clock,
+            active: location.pathname === '/sessions' || location.pathname.startsWith('/session/'),
+          },
+          {
+            path: '/blind/new',
+            label: '블라인드 테이스팅',
+            Icon: EyeOff,
+            active: location.pathname.startsWith('/blind/'),
+          },
+        ].map(({ path, label, Icon, active }) => (
+          <Link
+            key={path}
+            to={path}
+            title={!isExpanded ? label : undefined}
+            className={cn(
+              'flex items-center gap-3 py-2.5 rounded-lg transition-colors mb-1',
+              isExpanded ? 'px-3' : 'justify-center px-0',
+              active
+                ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                : 'text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+            )}
+          >
+            <Icon className="w-5 h-5 shrink-0" />
+            {isExpanded && <span className="truncate text-sm">{label}</span>}
+          </Link>
+        ))}
+      </div>
 
       {/* 하단: 알림, 설정 */}
       <div className={cn('py-2 border-t border-sidebar-border overflow-hidden', isExpanded ? 'px-2' : 'px-1')}>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,7 +1,8 @@
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Home, Search, FileText, MessageSquare, Package } from 'lucide-react';
+import { Home, Search, FileText, MessageSquare, Package, MoreHorizontal } from 'lucide-react';
 import { cn } from './ui/utils';
+import { MoreMenu } from './MoreMenu';
 
 type BottomNavItem = {
   label: string;
@@ -37,11 +38,18 @@ const NAV_ITEMS: BottomNavItem[] = [
   },
 ];
 
+const MORE_PATHS = ['/saved', '/sessions', '/settings'];
+const isMoreActive = (pathname: string) =>
+  MORE_PATHS.includes(pathname) ||
+  pathname.startsWith('/session/') ||
+  pathname.startsWith('/blind/');
+
 type BottomNavProps = HTMLAttributes<HTMLElement>;
 
 export function BottomNav({ className, ...rest }: BottomNavProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const [moreOpen, setMoreOpen] = useState(false);
 
   const handleNavigate = (path: string) => {
     if (location.pathname !== path) {
@@ -50,52 +58,75 @@ export function BottomNav({ className, ...rest }: BottomNavProps) {
   };
 
   return (
-    <nav
-      className={cn(
-        'fixed bottom-0 left-0 right-0 z-60 bg-card/95 backdrop-blur-md border-t border-black/5 rounded-t-2xl card-shadow-top px-4 py-3',
-        'pb-[calc(0.75rem+env(safe-area-inset-bottom))]',
-        'flex items-center justify-around',
-        'md:hidden',
-        className,
-      )}
-      {...rest}
-    >
-      {NAV_ITEMS.map((item) => {
-        const isActive = item.isActive
-          ? item.isActive(location.pathname)
-          : location.pathname === item.path;
-        const Icon = item.icon;
-        const isBoldActive = isActive && item.activeStyle === 'bold';
-        const isFillActive = isActive && item.activeStyle === 'fill';
-        const strokeWidth = isBoldActive ? 2.75 : 2;
-        const fill = isFillActive ? 'currentColor' : 'none';
-        return (
-          <button
-            key={item.path}
-            onClick={() => handleNavigate(item.path)}
-            className={cn(
-              'min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-1 transition-all duration-200 active:scale-95',
-              isActive ? 'text-primary' : 'text-muted-foreground',
-            )}
-            aria-label={item.label}
-          >
-            <div
+    <>
+      <nav
+        className={cn(
+          'fixed bottom-0 left-0 right-0 z-60 bg-card/95 backdrop-blur-md border-t border-black/5 rounded-t-2xl card-shadow-top px-2 py-3',
+          'pb-[calc(0.75rem+env(safe-area-inset-bottom))]',
+          'flex items-center justify-around',
+          'md:hidden',
+          className,
+        )}
+        {...rest}
+      >
+        {NAV_ITEMS.map((item) => {
+          const isActive = item.isActive
+            ? item.isActive(location.pathname)
+            : location.pathname === item.path;
+          const Icon = item.icon;
+          const isBoldActive = isActive && item.activeStyle === 'bold';
+          const isFillActive = isActive && item.activeStyle === 'fill';
+          const strokeWidth = isBoldActive ? 2.75 : 2;
+          const fill = isFillActive ? 'currentColor' : 'none';
+          return (
+            <button
+              key={item.path}
+              onClick={() => handleNavigate(item.path)}
               className={cn(
-                'w-6 h-6 flex items-center justify-center',
-                isActive && 'rounded-full',
+                'min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-1 transition-all duration-200 active:scale-95',
+                isActive ? 'text-primary' : 'text-muted-foreground',
               )}
+              aria-label={item.label}
             >
-              <Icon
-                className={cn('w-5 h-5 transition-all duration-200', isActive && 'text-primary')}
-                fill={fill}
-                stroke="currentColor"
-                strokeWidth={strokeWidth}
-              />
-            </div>
-            <span className="text-xs sm:text-xs font-medium">{item.label}</span>
-          </button>
-        );
-      })}
-    </nav>
+              <div
+                className={cn(
+                  'w-6 h-6 flex items-center justify-center',
+                  isActive && 'rounded-full',
+                )}
+              >
+                <Icon
+                  className={cn('w-5 h-5 transition-all duration-200', isActive && 'text-primary')}
+                  fill={fill}
+                  stroke="currentColor"
+                  strokeWidth={strokeWidth}
+                />
+              </div>
+              <span className="text-xs font-medium">{item.label}</span>
+            </button>
+          );
+        })}
+        <button
+          onClick={() => setMoreOpen(true)}
+          className={cn(
+            'min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-1 transition-all duration-200 active:scale-95',
+            isMoreActive(location.pathname) ? 'text-primary' : 'text-muted-foreground',
+          )}
+          aria-label="더보기"
+        >
+          <div className="w-6 h-6 flex items-center justify-center">
+            <MoreHorizontal
+              className={cn(
+                'w-5 h-5 transition-all duration-200',
+                isMoreActive(location.pathname) && 'text-primary',
+              )}
+              stroke="currentColor"
+              strokeWidth={isMoreActive(location.pathname) ? 2.75 : 2}
+            />
+          </div>
+          <span className="text-xs font-medium">더보기</span>
+        </button>
+      </nav>
+      <MoreMenu open={moreOpen} onOpenChange={setMoreOpen} />
+    </>
   );
 }

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -1,0 +1,69 @@
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from './ui/drawer';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Bookmark, Clock, EyeOff, Settings } from 'lucide-react';
+import { cn } from './ui/utils';
+
+interface MoreMenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function MoreMenu({ open, onOpenChange }: MoreMenuProps) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const isActive = (path: string) => {
+    if (path === '/saved') return pathname === '/saved';
+    if (path === '/sessions') return pathname === '/sessions' || pathname.startsWith('/session/');
+    if (path === '/blind/new') return pathname.startsWith('/blind/');
+    if (path === '/settings') return pathname === '/settings';
+    return false;
+  };
+
+  const handleNavigate = (path: string) => {
+    navigate(path);
+    onOpenChange(false);
+  };
+
+  const menuItems = [
+    { path: '/saved', label: '저장함', icon: Bookmark },
+    { path: '/sessions', label: '시음 세션', icon: Clock },
+    { path: '/blind/new', label: '블라인드 테이스팅', icon: EyeOff },
+  ];
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange} direction="bottom">
+      <DrawerContent className="z-70">
+        <DrawerHeader>
+          <DrawerTitle>더보기</DrawerTitle>
+        </DrawerHeader>
+        <div className="pb-[calc(1rem+env(safe-area-inset-bottom))]">
+          {menuItems.map(({ path, label, icon: Icon }) => (
+            <button
+              key={path}
+              onClick={() => handleNavigate(path)}
+              className={cn(
+                'flex w-full items-center gap-3 py-3 px-6',
+                isActive(path) ? 'text-primary font-medium' : 'text-foreground',
+              )}
+            >
+              <Icon className="w-5 h-5" />
+              {label}
+            </button>
+          ))}
+          <div className="mx-6 my-1 border-t border-border" />
+          <button
+            onClick={() => handleNavigate('/settings')}
+            className={cn(
+              'flex w-full items-center gap-3 py-3 px-6',
+              isActive('/settings') ? 'text-primary font-medium' : 'text-foreground',
+            )}
+          >
+            <Settings className="w-5 h-5" />
+            설정
+          </button>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## Summary

- BottomNav에 6번째 '더보기' 탭 추가 (기존 5탭 찻장·홈·탐색·차담·내 차록 모두 유지)
- `MoreMenu` 컴포넌트 신규 생성: vaul Drawer 기반 Bottom Sheet로 숨겨진 기능 노출
- `AppSidebar`에 데스크톱 "더보기" 섹션 추가

## Changes

### `src/components/MoreMenu.tsx` (신규)
- 저장함(`/saved`), 시음 세션(`/sessions`), 블라인드 테이스팅(`/blind/new`), 설정(`/settings`) 진입점 제공
- 현재 경로 활성 스타일 표시
- safe-area-inset 처리

### `src/components/BottomNav.tsx`
- 6번째 "더보기" 탭 추가 (MoreHorizontal 아이콘)
- `/saved`, `/sessions`, `/session/*`, `/blind/*`, `/settings` 경로에서 더보기 탭 활성

### `src/components/AppSidebar.tsx`
- 저장함, 시음 세션, 블라인드 테이스팅 링크 섹션 추가
- 사이드바 접힘/펼침 양쪽 지원

## Test plan

- [ ] 모바일: "더보기" 탭 클릭 시 Bottom Sheet 정상 노출
- [ ] 저장함·시음 세션·블라인드 테이스팅·설정 각 항목 클릭 후 정상 이동
- [ ] 해당 페이지에서 "더보기" 탭 활성 상태 확인
- [ ] 데스크톱 사이드바에 추가 항목 정상 노출

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)