### PR TITLE
feat: #225 민감 정보 노출 방지 (Health 엔드포인트 + 에러 로깅)

### DIFF
--- a/backend/src/common/http-exception.filter.ts
+++ b/backend/src/common/http-exception.filter.ts
@@ -54,12 +54,21 @@ export class HttpExceptionFilter implements ExceptionFilter {
         `Unhandled Exception: ${exception.message}`,
         exception.stack,
       );
+      const SENSITIVE_FIELDS = ['password', 'token', 'refreshToken', 'access_token', 'refresh_token'];
+      const sanitizeBody = (body: Record<string, unknown>) => {
+        if (!body || typeof body !== 'object') return body;
+        return Object.fromEntries(
+          Object.entries(body).map(([k, v]) =>
+            SENSITIVE_FIELDS.includes(k) ? [k, '[REDACTED]'] : [k, v]
+          )
+        );
+      };
       this.logger.error(
         `Request Details: ${request.method} ${request.url}`,
         JSON.stringify({
           query: request.query,
           params: request.params,
-          body: request.body,
+          body: sanitizeBody(request.body),
           headers: {
             'content-type': request.headers['content-type'],
             'authorization': request.headers['authorization'] ? '[REDACTED]' : undefined,

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -33,7 +33,12 @@ export class HealthController {
 
       const environment = this.configService.get('NODE_ENV') || 'development';
       const port = this.configService.get('PORT') || '3000';
-      
+      const isProd = environment === 'production';
+
+      if (isProd) {
+        return { status: 'healthy', timestamp };
+      }
+
       return {
         status: 'healthy',
         service: 'ChaLog Backend API',

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, BadRequestException } from '@nestjs/common';
+import { ValidationPipe, BadRequestException, Logger } from '@nestjs/common';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
@@ -82,7 +82,11 @@ async function bootstrap() {
             children: c.children?.map((cc) => ({ property: cc.property, constraints: cc.constraints })),
           })),
         }));
-        console.error('[ValidationPipe] Validation failed:', JSON.stringify(details, null, 2));
+        if (process.env.NODE_ENV !== 'production') {
+          console.error('[ValidationPipe] Validation failed:', JSON.stringify(details, null, 2));
+        } else {
+          console.error('[ValidationPipe] Validation failed fields:', details.map((e) => e.property));
+        }
         const flatten = (arr: typeof details): string[] =>
           arr.flatMap((e) => [
             ...(e.constraints ? Object.values(e.constraints) : []),
@@ -97,7 +101,7 @@ async function bootstrap() {
 
   const port = parseInt((configService.get('PORT') as string) || '3000', 10);
   await app.listen(port);
-  console.log(`Application is running on: http://localhost:${port}`);
+  Logger.log(`Application is running on: http://localhost:${port}`, 'Bootstrap');
 }
 
 bootstrap().catch((error) => {


### PR DESCRIPTION
## Summary
- `health.controller.ts`: 프로덕션(`NODE_ENV=production`)에서 `{ status, timestamp }` 만 반환
- `main.ts` ValidationPipe: 프로덕션에서 필드명만 로깅, 값 제외
- `http-exception.filter.ts`: request body의 `password`, `token`, `refreshToken` 등 → `[REDACTED]`
- `main.ts` startup `console.log` → NestJS `Logger.log` 교체

## Test plan
- [x] `cd backend && npm run build` 성공
- [x] 프리커밋 lint 통과
- [ ] `NODE_ENV=production` 설정 후 `/health` 응답에 `nodeVersion`, `memoryUsage` 미포함 확인
- [ ] 잘못된 비밀번호로 회원가입 시 서버 로그에 password 값 미노출 확인

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)