### PR TITLE
feat: #226 비밀번호 정책 강화 (최소 8자, 복잡도, 최대 72자)

### DIFF
--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MinLength, MaxLength, Matches } from 'class-validator';
 
 export class RegisterDto {
   @IsEmail()
@@ -9,7 +9,9 @@ export class RegisterDto {
   name: string;
 
   @IsString()
-  @MinLength(6)
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @MaxLength(72, { message: '비밀번호는 최대 72자 이하여야 합니다.' })
+  @Matches(/^(?=.*[A-Za-z])(?=.*\d).+$/, { message: '비밀번호는 영문자와 숫자를 모두 포함해야 합니다.' })
   password: string;
 }
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, BadRequestException } from '@nestjs/common';
+import { ValidationPipe, BadRequestException, Logger } from '@nestjs/common';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
@@ -97,7 +97,7 @@ async function bootstrap() {
 
   const port = parseInt((configService.get('PORT') as string) || '3000', 10);
   await app.listen(port);
-  console.log(`Application is running on: http://localhost:${port}`);
+  Logger.log(`Application is running on: http://localhost:${port}`, 'Bootstrap');
 }
 
 bootstrap().catch((error) => {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { Mail, Lock, User, Loader2 } from 'lucide-react';
 import { Header } from '../components/Header';
@@ -7,6 +7,18 @@ import { Button } from '../components/ui/button';
 import { Label } from '../components/ui/label';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
+
+function getPasswordStrength(pw: string): { level: 'weak' | 'medium' | 'strong'; label: string; color: string } {
+  const hasLetter = /[A-Za-z]/.test(pw);
+  const hasNumber = /\d/.test(pw);
+  const hasSpecial = /[^A-Za-z0-9]/.test(pw);
+  const isLong = pw.length >= 12;
+
+  if (pw.length === 0) return { level: 'weak', label: '', color: '' };
+  if (pw.length < 8 || !hasLetter || !hasNumber) return { level: 'weak', label: '약함', color: 'bg-red-500' };
+  if (hasLetter && hasNumber && hasSpecial && isLong) return { level: 'strong', label: '강함', color: 'bg-green-500' };
+  return { level: 'medium', label: '보통', color: 'bg-yellow-500' };
+}
 
 export function Register() {
   const navigate = useNavigate();
@@ -17,16 +29,28 @@ export function Register() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
+  const strength = getPasswordStrength(password);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!name.trim() || !email.trim() || !password.trim()) {
       toast.error('모든 필드를 입력해주세요.');
       return;
     }
 
-    if (password.length < 6) {
-      toast.error('비밀번호는 최소 6자 이상이어야 합니다.');
+    if (password.length < 8) {
+      toast.error('비밀번호는 최소 8자 이상이어야 합니다.');
+      return;
+    }
+
+    if (!/[A-Za-z]/.test(password) || !/\d/.test(password)) {
+      toast.error('비밀번호는 영문자와 숫자를 모두 포함해야 합니다.');
+      return;
+    }
+
+    if (password.length > 72) {
+      toast.error('비밀번호는 최대 72자 이하여야 합니다.');
       return;
     }
 
@@ -50,7 +74,7 @@ export function Register() {
   return (
     <div className="min-h-screen">
       <Header showBack title="회원가입" showProfile />
-      
+
       <div className="p-4 sm:max-w-md sm:mx-auto">
         <div className="bg-card rounded-lg p-6 space-y-6">
           <div>
@@ -100,13 +124,39 @@ export function Register() {
                 <Input
                   id="password"
                   type="password"
-                  placeholder="비밀번호를 입력하세요 (최소 6자)"
+                  placeholder="최소 8자, 영문+숫자 포함"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   className="pl-10"
                   disabled={isLoading}
                 />
               </div>
+              {password.length > 0 && (
+                <div className="space-y-1">
+                  <div className="flex gap-1">
+                    {(['weak', 'medium', 'strong'] as const).map((level, i) => (
+                      <div
+                        key={level}
+                        className={`h-1 flex-1 rounded-full transition-colors ${
+                          strength.level === 'weak' && i === 0 ? 'bg-red-500' :
+                          strength.level === 'medium' && i <= 1 ? 'bg-yellow-500' :
+                          strength.level === 'strong' ? 'bg-green-500' :
+                          'bg-muted'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  {strength.label && (
+                    <p className={`text-xs font-medium ${
+                      strength.level === 'weak' ? 'text-red-500' :
+                      strength.level === 'medium' ? 'text-yellow-600' :
+                      'text-green-600'
+                    }`}>
+                      비밀번호 강도: {strength.label}
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
 
             <div className="space-y-2">
@@ -148,4 +198,3 @@ export function Register() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- `register.dto.ts`: `@MinLength(8)`, `@MaxLength(72)`, `@Matches` (영문+숫자 필수) + 한글 에러 메시지
- `Register.tsx`: 비밀번호 강도 표시 UI 3단계 (약함 빨강 / 보통 노랑 / 강함 초록)
- 프론트엔드 유효성 검사 한글화 및 강화

## Test plan
- [x] `cd backend && npm run build` 성공
- [x] 프론트엔드 빌드 성공
- [x] 프리커밋 lint 통과
- [ ] 6자 비밀번호 → 400 에러
- [ ] 숫자만 8자 → 400 에러
- [ ] 73자 비밀번호 → 400 에러
- [ ] 프론트: 강도 표시 UI 3단계 정상 동작

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)