### PR TITLE
feat: #207 홈 페이지 간소화 및 탐색 페이지 강화

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,373 +1,230 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { Header } from '../components/Header';
-import { HeroSection } from '../components/HeroSection';
 import { NoteCard } from '../components/NoteCard';
 import { EmptyState } from '../components/EmptyState';
-import { TeaCard } from '../components/TeaCard';
-import { CreatorCard } from '../components/CreatorCard';
-import { UserAvatar } from '../components/ui/UserAvatar';
 import { BottomNav } from '../components/BottomNav';
-import { Section } from '../components/ui/Section';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
-import { teasApi, notesApi, tagsApi, usersApi } from '../lib/api';
-import { Tea, Note, PopularTagItem } from '../types';
+import { notesApi } from '../lib/api';
+import { Note } from '../types';
 import { logger } from '../lib/logger';
-import { Loader2, Hash, MessageCircle, ChevronRight } from 'lucide-react';
+import { PenLine, Compass, BookOpen, X, MessageCircle, ChevronRight } from 'lucide-react';
 import { usePullToRefreshForPage } from '../contexts/PullToRefreshContext';
 import { NoteCardSkeleton } from '../components/NoteCardSkeleton';
-import { TeaCardSkeleton } from '../components/TeaCardSkeleton';
 import { toast } from 'sonner';
 import { useAuth } from '../contexts/AuthContext';
 import { Button } from '../components/ui/button';
-import { Link } from 'react-router-dom';
 import { cn } from '../components/ui/utils';
-import { CARD_WIDTH, CARD_CONTAINER_CLASSES, CARD_ITEM_WRAPPER_CLASSES } from '../constants';
+import { CARD_CONTAINER_CLASSES, CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH } from '../constants';
 
-type FeedTab = 'forYou' | 'following' | 'tags';
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+const BANNER_KEY = 'home_banner_dismissed';
 
 export function Home() {
   const navigate = useNavigate();
-  const { user: currentUser, isLoading: authLoading } = useAuth();
-  const [trendingTeas, setTrendingTeas] = useState<Tea[]>([]);
-  const [trendingCreators, setTrendingCreators] = useState<Array<{ id: number; name: string; profileImageUrl?: string | null } & { followerCount: number }>>([]);
-  const [publicNotes, setPublicNotes] = useState<Note[]>([]);
-  const [followingNotes, setFollowingNotes] = useState<Note[]>([]);
-  const [tagNotes, setTagNotes] = useState<Note[]>([]);
-  const [followedTags, setFollowedTags] = useState<PopularTagItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isFollowingLoading, setIsFollowingLoading] = useState(false);
-  const [isTagsLoading, setIsTagsLoading] = useState(false);
-  const [activeTab, setActiveTab] = useState<FeedTab>('forYou');
+  const { user: currentUser } = useAuth();
+  const [myRecentNotes, setMyRecentNotes] = useState<Note[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [bannerDismissed, setBannerDismissed] = useState(
+    () => localStorage.getItem(BANNER_KEY) === 'true',
+  );
 
-  const fetchForYouFeed = useCallback(async (opts?: { silent?: boolean }) => {
-    try {
-      if (!opts?.silent) setIsLoading(true);
-      
-      const [notesResult, trendingTeasResult, trendingCreatorsResult] = await Promise.allSettled([
-        notesApi.getAll(undefined, true),
-        teasApi.getTrending('7d'),
-        usersApi.getTrending('7d'),
-      ]);
+  const today = useMemo(() => new Date(), []);
 
-      if (notesResult.status === 'fulfilled') {
-        const notesArray = Array.isArray(notesResult.value) ? notesResult.value : [];
-        setPublicNotes(notesArray as Note[]);
-      } else {
-        const error = notesResult.reason;
-        logger.error('Failed to fetch notes:', error);
-        if (error?.statusCode === 429) {
-          toast.error('요청이 너무 많습니다. 잠시 후 다시 시도해주세요.');
-        } else {
-          toast.error('차록 정보를 불러오는데 실패했습니다.');
-        }
+  const weekDates = useMemo(() => {
+    const day = today.getDay();
+    return Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(today);
+      d.setDate(today.getDate() - day + i);
+      return d;
+    });
+  }, [today]);
+
+  const fetchMyNotes = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      if (!currentUser) return;
+      try {
+        if (!opts?.silent) setIsLoading(true);
+        const data = await notesApi.getAll(
+          currentUser.id,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'latest',
+          1,
+          5,
+        );
+        setMyRecentNotes(Array.isArray(data) ? (data as Note[]) : []);
+      } catch (error) {
+        logger.error('Failed to fetch my notes:', error);
+      } finally {
+        setIsLoading(false);
       }
-
-      if (trendingTeasResult.status === 'fulfilled') {
-        const arr = Array.isArray(trendingTeasResult.value) ? trendingTeasResult.value : [];
-        setTrendingTeas(arr as Tea[]);
-      } else {
-        logger.error('Failed to fetch trending teas:', trendingTeasResult.reason);
-      }
-
-      if (trendingCreatorsResult.status === 'fulfilled') {
-        const arr = Array.isArray(trendingCreatorsResult.value) ? trendingCreatorsResult.value : [];
-        setTrendingCreators(arr);
-      } else {
-        logger.error('Failed to fetch trending creators:', trendingCreatorsResult.reason);
-      }
-    } catch (error) {
-      logger.error('Failed to fetch data:', error);
-      toast.error('데이터를 불러오는데 실패했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  const fetchFollowingFeed = useCallback(async () => {
-    if (!currentUser) return;
-    try {
-      setIsFollowingLoading(true);
-      const notesData = await notesApi.getAll(undefined, undefined, undefined, undefined, 'following');
-      const notesArray = Array.isArray(notesData) ? notesData : [];
-      setFollowingNotes(notesArray as Note[]);
-    } catch (error) {
-      logger.error('Failed to fetch following notes:', error);
-      toast.error('구독 피드를 불러오는데 실패했습니다.');
-    } finally {
-      setIsFollowingLoading(false);
-    }
-  }, [currentUser]);
-
-  const fetchTagsFeed = useCallback(async () => {
-    if (!currentUser) return;
-    try {
-      setIsTagsLoading(true);
-      const [notesData, tagsData] = await Promise.all([
-        notesApi.getAll(undefined, undefined, undefined, undefined, 'tags'),
-        tagsApi.getFollowedTags(),
-      ]);
-      const notesArray = Array.isArray(notesData) ? notesData : [];
-      setTagNotes(notesArray as Note[]);
-      setFollowedTags(Array.isArray(tagsData) ? tagsData : []);
-    } catch (error) {
-      logger.error('Failed to fetch tag feed:', error);
-      toast.error('향미 차록 흐름을 불러오는데 실패했습니다.');
-    } finally {
-      setIsTagsLoading(false);
-    }
-  }, [currentUser]);
+    },
+    [currentUser],
+  );
 
   useEffect(() => {
-    fetchForYouFeed();
-  }, [fetchForYouFeed]);
-
-  useEffect(() => {
-    if (activeTab === 'following' && currentUser && !authLoading) {
-      fetchFollowingFeed();
-    }
-  }, [activeTab, currentUser, authLoading, fetchFollowingFeed]);
-
-  useEffect(() => {
-    if (activeTab === 'tags' && currentUser && !authLoading) {
-      fetchTagsFeed();
-    }
-  }, [activeTab, currentUser, authLoading, fetchTagsFeed]);
+    fetchMyNotes();
+  }, [fetchMyNotes]);
 
   const handleRefresh = useCallback(async () => {
-    await fetchForYouFeed({ silent: true });
-    if (activeTab === 'following' && currentUser) await fetchFollowingFeed();
-    if (activeTab === 'tags' && currentUser) await fetchTagsFeed();
-  }, [fetchForYouFeed, fetchFollowingFeed, fetchTagsFeed, activeTab, currentUser]);
+    await fetchMyNotes({ silent: true });
+  }, [fetchMyNotes]);
 
   usePullToRefreshForPage(handleRefresh, '/');
 
-  const recentContributors = useMemo(() => {
-    const seen = new Set<number>();
-    return publicNotes
-      .filter((n) => {
-        if (seen.has(n.userId)) return false;
-        seen.add(n.userId);
-        return true;
-      })
-      .map((n) => ({ id: n.userId, name: n.userName }));
-  }, [publicNotes]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen pb-20">
-        <Header showProfile showLogo />
-        <div className="px-4 py-6 pb-20 sm:px-6 sm:py-8 space-y-6 sm:space-y-8">
-          <HeroSection />
-          <Section title="📄 차록 흐름" description="다양한 차록을 둘러보세요." spacing="lg">
-            <div className="space-y-3">
-              {[1, 2, 3, 4].map((i) => (
-                <NoteCardSkeleton key={i} />
-              ))}
-            </div>
-          </Section>
-          <footer className="mt-12 pt-8 pb-6 border-t border-border/40">
-            <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-              <span>차멍 v0.1</span>
-              <span className="text-border">·</span>
-              <span>이용약관</span>
-              <span className="text-border">·</span>
-              <span>개인정보처리방침</span>
-            </div>
-            <p className="text-center text-[10px] text-muted-foreground/60 mt-3">© 2026 차멍. All rights reserved.</p>
-          </footer>
-        </div>
-        <BottomNav />
-      </div>
-    );
-  }
+  const handleDismissBanner = () => {
+    setBannerDismissed(true);
+    localStorage.setItem(BANNER_KEY, 'true');
+  };
 
   return (
     <div className="min-h-screen pb-20">
       <Header showProfile showLogo />
-      <div className="px-4 py-6 pb-20 sm:px-6 sm:py-8 space-y-6 sm:space-y-8">
-        {/* Hero - 차멍 설명 */}
-        <HeroSection />
+      <div className="px-4 py-6 pb-20 sm:px-6 sm:py-8 space-y-6">
 
-        {/* 요즘 인기 차 섹션 */}
-        <Section title="🍵 요즘 인기 차" description="최근 7일간 차록이 많은 인기 차예요." spacing="lg">
-          {trendingTeas.length > 0 ? (
-            <div className={CARD_CONTAINER_CLASSES}>
-              {trendingTeas.map((tea) => (
-                <div key={tea.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE)}>
-                  <TeaCard tea={tea} />
-                </div>
-              ))}
+        {/* 배너 */}
+        {!bannerDismissed && (
+          <div className="relative flex items-center gap-3 p-4 rounded-2xl bg-primary/8 border border-primary/15">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-foreground">차멍에 오신 것을 환영해요 🍵</p>
+              <p className="text-xs text-muted-foreground mt-0.5">오늘도 좋은 차 한 잔 기록해보세요.</p>
             </div>
-          ) : (
-            <EmptyState type="feed" message="아직 트렌딩 차가 없습니다." />
-          )}
-        </Section>
-
-        {/* 인기 다우 섹션 */}
-        <Section title="🌿 인기 다우" description="구독자가 많은 인기 다우를 만나보세요." spacing="lg">
-          {trendingCreators.length > 0 ? (
-            <div className={CARD_CONTAINER_CLASSES}>
-              {trendingCreators.map((creator) => (
-                <div key={creator.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.DEFAULT)}>
-                  <CreatorCard user={creator} followerCount={creator.followerCount} />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <EmptyState type="feed" message="아직 인기 다우가 없습니다." />
-          )}
-        </Section>
-
-        {/* 차록 흐름 탭 섹션 */}
-        <Section title="📄 차록 흐름" description="다양한 차록을 둘러보세요." spacing="lg">
-        <Tabs
-          value={activeTab}
-          onValueChange={(v) => setActiveTab(v as FeedTab)}
-        >
-          <TabsList className="w-full">
-            <TabsTrigger value="forYou" className="flex-1">맞춤차</TabsTrigger>
-            <TabsTrigger value="following" className="flex-1">구독</TabsTrigger>
-            <TabsTrigger value="tags" className="flex-1">향미</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="forYou" className="mt-4">
-            {publicNotes.length > 0 ? (
-              <div className={CARD_CONTAINER_CLASSES}>
-                {publicNotes.map((note, i) => (
-                  <div
-                    key={note.id}
-                    className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE, 'animate-fade-in-up opacity-0')}
-                    style={{ animationDelay: `${i * 50}ms` }}
-                  >
-                    <NoteCard note={note} showTeaName />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <EmptyState
-                type="feed"
-                message="아직 등록된 차록이 없어요. 첫 차록을 남겨볼까요?"
-                action={{ label: '첫 차록 쓰기', onClick: () => navigate('/note/new') }}
-              />
-            )}
-          </TabsContent>
-
-          <TabsContent value="following" className="mt-4">
-            {!currentUser && !authLoading ? (
-              <div className="flex flex-col items-center gap-4 py-12 text-center">
-                <p className="text-muted-foreground text-sm">
-                  구독한 다우의 차록을 보려면 로그인이 필요합니다.
-                </p>
-                <Button size="sm" onClick={() => navigate('/login')}>
-                  로그인하기
-                </Button>
-              </div>
-            ) : isFollowingLoading ? (
-              <div className="flex justify-center py-12">
-                <Loader2 className="w-8 h-8 text-primary animate-spin" />
-              </div>
-            ) : followingNotes.length > 0 ? (
-              <div className={CARD_CONTAINER_CLASSES}>
-                {followingNotes.map(note => (
-                  <div key={note.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE)}>
-                    <NoteCard note={note} showTeaName />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <EmptyState
-                type="feed"
-                message="구독한 다우의 차록이 없어요. 다우를 구독해 보세요!"
-                action={{ label: '탐색하기', onClick: () => navigate('/sasaek') }}
-              />
-            )}
-          </TabsContent>
-
-          <TabsContent value="tags" className="mt-4">
-            {!currentUser && !authLoading ? (
-              <div className="flex flex-col items-center gap-4 py-12 text-center">
-                <p className="text-muted-foreground text-sm">
-                  구독한 향미 차록을 보려면 로그인이 필요합니다.
-                </p>
-                <Button size="sm" onClick={() => navigate('/login')}>
-                  로그인하기
-                </Button>
-              </div>
-            ) : isTagsLoading ? (
-              <div className="flex justify-center py-12">
-                <Loader2 className="w-8 h-8 text-primary animate-spin" />
-              </div>
-            ) : (
-              <>
-                {/* 구독 중인 향미 pill */}
-                {followedTags.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mb-4 pb-3 border-b border-border/50">
-                    {followedTags.map((tag) => (
-                      <Link
-                        key={tag.name}
-                        to={`/tag/${encodeURIComponent(tag.name)}`}
-                        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
-                      >
-                        <Hash className="w-3 h-3" />
-                        {tag.name}
-                      </Link>
-                    ))}
-                  </div>
-                )}
-                {tagNotes.length > 0 ? (
-                  <div className={CARD_CONTAINER_CLASSES}>
-                    {tagNotes.map(note => (
-                      <div key={note.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE)}>
-                        <NoteCard note={note} showTeaName />
-                      </div>
-                    ))}
-                  </div>
-                ) : followedTags.length === 0 ? (
-                  <div className="flex flex-col items-center gap-4 py-12 text-center">
-                    <Hash className="w-10 h-10 text-muted-foreground/30" />
-                    <p className="text-muted-foreground text-sm">
-                      구독한 향미가 없습니다.
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      향미를 클릭해 상세 페이지에서 구독해 보세요!
-                    </p>
-                  </div>
-                ) : (
-                  <EmptyState
-                    type="feed"
-                    message="구독한 테마의 공개 차록이 없어요."
-                    action={{ label: '테마 탐색하기', onClick: () => navigate('/sasaek') }}
-                  />
-                )}
-              </>
-            )}
-          </TabsContent>
-        </Tabs>
-        </Section>
-
-        {/* 최근 기여자 - 아주 작게 가로 스크롤 */}
-        {recentContributors.length > 0 && (
-          <div className="mt-8 pt-4 border-t border-black/5">
-            <p className="text-[10px] text-muted-foreground mb-2 px-1">최근 기여자</p>
-            <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 scrollbar-hide">
-              {recentContributors.map((c) => (
-                <Link
-                  key={c.id}
-                  to={`/user/${c.id}`}
-                  className="shrink-0 flex items-center gap-1.5 px-2 py-1 rounded-full bg-muted/50 hover:bg-muted transition-colors"
-                >
-                  <UserAvatar name={c.name} size="xs" className="shrink-0" />
-                  <span className="text-[10px] text-muted-foreground truncate max-w-[60px]">
-                    {c.name}
-                  </span>
-                </Link>
-              ))}
-            </div>
+            <button
+              type="button"
+              onClick={handleDismissBanner}
+              className="shrink-0 p-1 rounded-full hover:bg-muted/60 transition-colors"
+              aria-label="배너 닫기"
+            >
+              <X className="w-4 h-4 text-muted-foreground" />
+            </button>
           </div>
         )}
 
-        {/* 하단 푸터 - 오픈톡 + 개발정보 */}
+        {/* 빠른 접근 버튼 */}
+        <div className="grid grid-cols-3 gap-3">
+          {[
+            { icon: PenLine, label: '차록 쓰기', to: '/note/new' },
+            { icon: Compass, label: '탐색하기', to: '/sasaek' },
+            { icon: BookOpen, label: '내 차록', to: '/my-notes' },
+          ].map(({ icon: Icon, label, to }) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => navigate(to)}
+              className="flex flex-col items-center gap-2 py-4 rounded-2xl bg-muted/40 hover:bg-muted/70 transition-colors border border-border/40"
+            >
+              <Icon className="w-5 h-5 text-primary" />
+              <span className="text-xs font-medium text-foreground">{label}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* 오늘의 기록 카드 */}
+        <div className="rounded-2xl bg-card border border-border/60 p-5 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs text-muted-foreground">
+                {today.getFullYear()}년 {today.getMonth() + 1}월
+              </p>
+              <p className="text-lg font-semibold text-foreground">
+                {today.getDate()}일 {WEEKDAYS[today.getDay()]}요일
+              </p>
+            </div>
+            {currentUser && (
+              <button
+                type="button"
+                onClick={() => navigate('/note/new')}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 transition-colors"
+              >
+                <PenLine className="w-3.5 h-3.5" />
+                차록 쓰기
+              </button>
+            )}
+          </div>
+
+          {/* 주간 미니 캘린더 */}
+          <div className="flex gap-1">
+            {weekDates.map((d) => {
+              const isToday = d.toDateString() === today.toDateString();
+              return (
+                <div
+                  key={d.toDateString()}
+                  className={cn(
+                    'flex-1 flex flex-col items-center gap-1 py-2 rounded-xl',
+                    isToday ? 'bg-primary text-primary-foreground' : 'bg-muted/30',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'text-[10px]',
+                      isToday ? 'text-primary-foreground/80' : 'text-muted-foreground',
+                    )}
+                  >
+                    {WEEKDAYS[d.getDay()]}
+                  </span>
+                  <span
+                    className={cn(
+                      'text-sm font-medium',
+                      isToday ? 'text-primary-foreground' : 'text-foreground',
+                    )}
+                  >
+                    {d.getDate()}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* 최근 내 차록 */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold">최근 차록</h2>
+            {currentUser && (
+              <Link
+                to="/my-notes"
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                전체보기
+              </Link>
+            )}
+          </div>
+
+          {!currentUser ? (
+            <div className="flex flex-col items-center gap-4 py-12 text-center">
+              <p className="text-sm text-muted-foreground">
+                로그인하면 내 차록을 확인할 수 있어요.
+              </p>
+              <Button size="sm" onClick={() => navigate('/login')}>
+                로그인하기
+              </Button>
+            </div>
+          ) : isLoading ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <NoteCardSkeleton key={i} />
+              ))}
+            </div>
+          ) : myRecentNotes.length > 0 ? (
+            <div className={CARD_CONTAINER_CLASSES}>
+              {myRecentNotes.map((note) => (
+                <div key={note.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE)}>
+                  <NoteCard note={note} showTeaName />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState
+              type="feed"
+              message="아직 차록이 없어요. 첫 차록을 남겨볼까요?"
+              action={{ label: '차록 쓰기', onClick: () => navigate('/note/new') }}
+            />
+          )}
+        </div>
+
+        {/* 하단 푸터 */}
         <footer className="mt-12 pt-8 pb-6 border-t border-black/5">
           {import.meta.env.VITE_KAKAO_OPEN_CHAT_URL && (
             <a
@@ -381,12 +238,8 @@ export function Home() {
                   <MessageCircle className="w-5 h-5 text-[#191919]" />
                 </div>
                 <div className="text-left">
-                  <p className="text-sm font-semibold text-[#191919]">
-                    차에 대해 이야기해요
-                  </p>
-                  <p className="text-xs text-[#191919]/70 mt-0.5">
-                    오픈채팅에서 만나요
-                  </p>
+                  <p className="text-sm font-semibold text-[#191919]">차에 대해 이야기해요</p>
+                  <p className="text-xs text-[#191919]/70 mt-0.5">오픈채팅에서 만나요</p>
                 </div>
               </div>
               <ChevronRight className="w-5 h-5 text-[#191919]/60 group-hover:text-[#191919] group-hover:translate-x-0.5 transition-all shrink-0" />
@@ -395,15 +248,25 @@ export function Home() {
           <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground/80">
             <span>차멍 v0.1</span>
             <span className="text-border/60">·</span>
-            <button type="button" onClick={() => toast.info('준비 중입니다.')} className="text-[11px] font-normal hover:text-foreground/70 transition-colors">
+            <button
+              type="button"
+              onClick={() => toast.info('준비 중입니다.')}
+              className="text-[11px] font-normal hover:text-foreground/70 transition-colors"
+            >
               이용약관
             </button>
             <span className="text-border/60">·</span>
-            <button type="button" onClick={() => toast.info('준비 중입니다.')} className="text-[11px] font-normal hover:text-foreground/70 transition-colors">
+            <button
+              type="button"
+              onClick={() => toast.info('준비 중입니다.')}
+              className="text-[11px] font-normal hover:text-foreground/70 transition-colors"
+            >
               개인정보처리방침
             </button>
           </div>
-          <p className="text-center text-[10px] text-muted-foreground/60 mt-3">© 2026 차멍. All rights reserved.</p>
+          <p className="text-center text-[10px] text-muted-foreground/60 mt-3">
+            © 2026 차멍. All rights reserved.
+          </p>
         </footer>
       </div>
       <BottomNav />

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { usePullToRefreshForPage } from '../contexts/PullToRefreshContext';
-import { Search as SearchIcon, Plus, Store, Filter, Clock, X, ChevronDown, Package } from 'lucide-react';
+import { Search as SearchIcon, Plus, Store, Filter, Clock, X, ChevronDown, Package, Loader2, Hash } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { TeaCard } from '../components/TeaCard';
@@ -12,10 +12,12 @@ import { Input } from '../components/ui/input';
 import { Button } from '../components/ui/button';
 import { BottomNav } from '../components/BottomNav';
 import { Section } from '../components/ui/Section';
-import { teasApi, tagsApi, notesApi, cellarApi } from '../lib/api';
-import { Tea, Seller, Note, CellarItem } from '../types';
+import { teasApi, tagsApi, notesApi, cellarApi, usersApi } from '../lib/api';
+import { Tea, Seller, Note, CellarItem, PopularTagItem } from '../types';
 import { NoteCard } from '../components/NoteCard';
+import { CreatorCard } from '../components/CreatorCard';
 import { SellerCombobox } from '../components/SellerCombobox';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
 import { NoteCardSkeleton } from '../components/NoteCardSkeleton';
 import { toast } from 'sonner';
 import { logger } from '../lib/logger';
@@ -416,15 +418,69 @@ export function Search() {
   const [sellers, setSellers] = useState<Seller[]>([]);
   const [popularTags, setPopularTags] = useState<{ name: string; noteCount: number }[]>([]);
   const [sectionsLoading, setSectionsLoading] = useState(true);
+  const [trendingCreators, setTrendingCreators] = useState<Array<{ id: number; name: string; profileImageUrl?: string | null } & { followerCount: number }>>([]);
+
+  type ExploreFeedTab = 'forYou' | 'following' | 'tags';
+  const [exploreFeedTab, setExploreFeedTab] = useState<ExploreFeedTab>('forYou');
+  const [explorePublicNotes, setExplorePublicNotes] = useState<Note[]>([]);
+  const [exploreFollowingNotes, setExploreFollowingNotes] = useState<Note[]>([]);
+  const [exploreTagNotes, setExploreTagNotes] = useState<Note[]>([]);
+  const [exploreFollowedTags, setExploreFollowedTags] = useState<PopularTagItem[]>([]);
+  const [isExploreFeedLoading, setIsExploreFeedLoading] = useState(false);
+  const [isExploreFollowingLoading, setIsExploreFollowingLoading] = useState(false);
+  const [isExploreTagsLoading, setIsExploreTagsLoading] = useState(false);
+
+  const fetchExploreFeed = useCallback(async (opts?: { silent?: boolean }) => {
+    try {
+      if (!opts?.silent) setIsExploreFeedLoading(true);
+      const data = await notesApi.getAll(undefined, true);
+      setExplorePublicNotes(Array.isArray(data) ? (data as Note[]) : []);
+    } catch (error) {
+      logger.error('Failed to fetch explore feed:', error);
+    } finally {
+      setIsExploreFeedLoading(false);
+    }
+  }, []);
+
+  const fetchExploreFollowingFeed = useCallback(async () => {
+    if (!user) return;
+    try {
+      setIsExploreFollowingLoading(true);
+      const data = await notesApi.getAll(undefined, undefined, undefined, undefined, 'following');
+      setExploreFollowingNotes(Array.isArray(data) ? (data as Note[]) : []);
+    } catch (error) {
+      logger.error('Failed to fetch explore following feed:', error);
+    } finally {
+      setIsExploreFollowingLoading(false);
+    }
+  }, [user]);
+
+  const fetchExploreTagsFeed = useCallback(async () => {
+    if (!user) return;
+    try {
+      setIsExploreTagsLoading(true);
+      const [notesData, tagsData] = await Promise.all([
+        notesApi.getAll(undefined, undefined, undefined, undefined, 'tags'),
+        tagsApi.getFollowedTags(),
+      ]);
+      setExploreTagNotes(Array.isArray(notesData) ? (notesData as Note[]) : []);
+      setExploreFollowedTags(Array.isArray(tagsData) ? tagsData : []);
+    } catch (error) {
+      logger.error('Failed to fetch explore tags feed:', error);
+    } finally {
+      setIsExploreTagsLoading(false);
+    }
+  }, [user]);
 
   const fetchSections = useCallback(async () => {
     setSectionsLoading(true);
-    const [popularRes, newRes, curationRes, sellersRes, tagsRes] = await Promise.allSettled([
+    const [popularRes, newRes, curationRes, sellersRes, tagsRes, creatorsRes] = await Promise.allSettled([
       teasApi.getPopularRankings(10),
       teasApi.getNewRankings(3),
       teasApi.getCuration(3),
       teasApi.getSellers(),
       tagsApi.getPopularTags(15),
+      usersApi.getTrending('7d'),
     ]);
     if (popularRes.status === 'fulfilled') {
       setPopularTeas(Array.isArray(popularRes.value) ? popularRes.value : []);
@@ -454,6 +510,11 @@ export function Search() {
         })),
       );
     }
+    if (creatorsRes.status === 'fulfilled') {
+      setTrendingCreators(Array.isArray(creatorsRes.value) ? creatorsRes.value : []);
+    } else {
+      logger.error('Failed to fetch trending creators:', creatorsRes.reason);
+    }
     const anyFailed =
       popularRes.status === 'rejected' ||
       newRes.status === 'rejected' ||
@@ -463,7 +524,8 @@ export function Search() {
       toast.error('탐색 데이터를 불러오는데 실패했습니다.');
     }
     setSectionsLoading(false);
-  }, []);
+    fetchExploreFeed();
+  }, [fetchExploreFeed]);
 
   const handleSearch = useCallback(async (query: string) => {
     if (query.trim().length < 2) return;
@@ -672,6 +734,18 @@ export function Search() {
       fetchSections();
     }
   }, [searchQuery, hasSearched, hasFilterParams, fetchSections]);
+
+  useEffect(() => {
+    if (activeTab === 'explore' && exploreFeedTab === 'following' && user) {
+      fetchExploreFollowingFeed();
+    }
+  }, [activeTab, exploreFeedTab, user, fetchExploreFollowingFeed]);
+
+  useEffect(() => {
+    if (activeTab === 'explore' && exploreFeedTab === 'tags' && user) {
+      fetchExploreTagsFeed();
+    }
+  }, [activeTab, exploreFeedTab, user, fetchExploreTagsFeed]);
 
   useEffect(() => {
     if (showResults && popularTags.length === 0) {
@@ -1198,6 +1272,148 @@ export function Search() {
                   ) : (
                     <p className="text-sm text-muted-foreground py-4">엄선한 차가 없습니다.</p>
                   )}
+                </Section>
+
+                {/* 인기 다우 섹션 */}
+                {trendingCreators.length > 0 && (
+                  <Section
+                    title="🌿 인기 다우"
+                    description="구독자가 많은 인기 다우를 만나보세요."
+                    spacing="lg"
+                  >
+                    <div className={CARD_CONTAINER_CLASSES}>
+                      {trendingCreators.map((creator) => (
+                        <div key={creator.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.DEFAULT)}>
+                          <CreatorCard user={creator} followerCount={creator.followerCount} />
+                        </div>
+                      ))}
+                    </div>
+                  </Section>
+                )}
+
+                {/* 차록 흐름 섹션 */}
+                <Section title="📄 차록 흐름" description="다양한 차록을 둘러보세요." spacing="lg">
+                  <Tabs
+                    value={exploreFeedTab}
+                    onValueChange={(v) => setExploreFeedTab(v as 'forYou' | 'following' | 'tags')}
+                  >
+                    <TabsList className="w-full">
+                      <TabsTrigger value="forYou" className="flex-1">맞춤차</TabsTrigger>
+                      <TabsTrigger value="following" className="flex-1">구독</TabsTrigger>
+                      <TabsTrigger value="tags" className="flex-1">향미</TabsTrigger>
+                    </TabsList>
+
+                    <TabsContent value="forYou" className="mt-4">
+                      {isExploreFeedLoading ? (
+                        <div className="flex justify-center py-12">
+                          <Loader2 className="w-8 h-8 text-primary animate-spin" />
+                        </div>
+                      ) : explorePublicNotes.length > 0 ? (
+                        <div className={CARD_CONTAINER_CLASSES}>
+                          {explorePublicNotes.map((note, i) => (
+                            <div
+                              key={note.id}
+                              className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE, 'animate-fade-in-up opacity-0')}
+                              style={{ animationDelay: `${i * 50}ms` }}
+                            >
+                              <NoteCard note={note} showTeaName />
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <EmptyState type="feed" message="아직 등록된 차록이 없어요." />
+                      )}
+                    </TabsContent>
+
+                    <TabsContent value="following" className="mt-4">
+                      {!user ? (
+                        <div className="flex flex-col items-center gap-4 py-12 text-center">
+                          <p className="text-muted-foreground text-sm">
+                            구독한 다우의 차록을 보려면 로그인이 필요합니다.
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => navigate('/login')}
+                            className="px-4 py-2 rounded-full bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+                          >
+                            로그인하기
+                          </button>
+                        </div>
+                      ) : isExploreFollowingLoading ? (
+                        <div className="flex justify-center py-12">
+                          <Loader2 className="w-8 h-8 text-primary animate-spin" />
+                        </div>
+                      ) : exploreFollowingNotes.length > 0 ? (
+                        <div className={CARD_CONTAINER_CLASSES}>
+                          {exploreFollowingNotes.map((note) => (
+                            <div key={note.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE)}>
+                              <NoteCard note={note} showTeaName />
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <EmptyState type="feed" message="구독한 다우의 차록이 없어요." />
+                      )}
+                    </TabsContent>
+
+                    <TabsContent value="tags" className="mt-4">
+                      {!user ? (
+                        <div className="flex flex-col items-center gap-4 py-12 text-center">
+                          <p className="text-muted-foreground text-sm">
+                            구독한 향미 차록을 보려면 로그인이 필요합니다.
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => navigate('/login')}
+                            className="px-4 py-2 rounded-full bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+                          >
+                            로그인하기
+                          </button>
+                        </div>
+                      ) : isExploreTagsLoading ? (
+                        <div className="flex justify-center py-12">
+                          <Loader2 className="w-8 h-8 text-primary animate-spin" />
+                        </div>
+                      ) : (
+                        <>
+                          {exploreFollowedTags.length > 0 && (
+                            <div className="flex flex-wrap gap-1.5 mb-4 pb-3 border-b border-border/50">
+                              {exploreFollowedTags.map((tag) => (
+                                <button
+                                  key={tag.name}
+                                  type="button"
+                                  onClick={() => navigate(`/tag/${encodeURIComponent(tag.name)}`)}
+                                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                                >
+                                  <Hash className="w-3 h-3" />
+                                  {tag.name}
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                          {exploreTagNotes.length > 0 ? (
+                            <div className={CARD_CONTAINER_CLASSES}>
+                              {exploreTagNotes.map((note) => (
+                                <div key={note.id} className={cn(CARD_ITEM_WRAPPER_CLASSES, CARD_WIDTH.WIDE)}>
+                                  <NoteCard note={note} showTeaName />
+                                </div>
+                              ))}
+                            </div>
+                          ) : exploreFollowedTags.length === 0 ? (
+                            <div className="flex flex-col items-center gap-4 py-12 text-center">
+                              <Hash className="w-10 h-10 text-muted-foreground/30" />
+                              <p className="text-muted-foreground text-sm">구독한 향미가 없습니다.</p>
+                              <p className="text-xs text-muted-foreground">
+                                향미를 클릭해 상세 페이지에서 구독해 보세요!
+                              </p>
+                            </div>
+                          ) : (
+                            <EmptyState type="feed" message="구독한 향미의 공개 차록이 없어요." />
+                          )}
+                        </>
+                      )}
+                    </TabsContent>
+                  </Tabs>
                 </Section>
 
 <Section

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -1,26 +1,9 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, vi, describe, it, expect } from 'vitest';
 import { Home } from '../Home';
 import { renderWithRouter } from '../../test/renderWithRouter';
 
 const mockDate = new Date('2024-11-10T00:00:00.000Z');
-
-const mockTeas = [
-  {
-    id: 1,
-    name: '화과향',
-    type: '백차',
-    averageRating: 4.5,
-    reviewCount: 20,
-  },
-  {
-    id: 2,
-    name: '무이암차',
-    type: '청차/우롱차',
-    averageRating: 4.8,
-    reviewCount: 12,
-  },
-];
 
 const mockNotes = [
   {
@@ -30,50 +13,16 @@ const mockNotes = [
     userId: 1,
     userName: '김차인',
     rating: 4.5,
-    ratings: {
-      richness: 4,
-      strength: 4,
-      smoothness: 5,
-      clarity: 5,
-      complexity: 4,
-    },
-    memo: '공개 차록입니다.',
+    ratings: { richness: 4, strength: 4, smoothness: 5, clarity: 5, complexity: 4 },
+    memo: '내 최근 차록입니다.',
     isPublic: true,
-    createdAt: mockDate,
-  },
-  {
-    id: 2,
-    teaId: 2,
-    teaName: '무이암차',
-    userId: 2,
-    userName: '이다원',
-    rating: 4.2,
-    ratings: {
-      richness: 3,
-      strength: 3,
-      smoothness: 4,
-      clarity: 4,
-      complexity: 3,
-    },
-    memo: '비공개 차록입니다.',
-    isPublic: false,
     createdAt: mockDate,
   },
 ];
 
 vi.mock('../../lib/api', () => ({
-  teasApi: {
-    getAll: vi.fn(() => Promise.resolve(mockTeas)),
-    getTrending: vi.fn(() => Promise.resolve(mockTeas)),
-  },
   notesApi: {
-    getAll: vi.fn(() => Promise.resolve(mockNotes.filter(note => note.isPublic))),
-  },
-  usersApi: {
-    getTrending: vi.fn(() => Promise.resolve([])),
-  },
-  tagsApi: {
-    getFollowedTags: vi.fn(() => Promise.resolve([])),
+    getAll: vi.fn(() => Promise.resolve(mockNotes)),
   },
 }));
 
@@ -82,18 +31,15 @@ vi.mock('../../contexts/AuthContext', async (importOriginal) => {
   return {
     ...actual,
     useAuth: () => ({
-      user: null,
+      user: { id: 1, name: '김차인' },
       isLoading: false,
-      isAuthenticated: false,
+      isAuthenticated: true,
     }),
   };
 });
 
 vi.mock('sonner', () => ({
-  toast: {
-    error: vi.fn(),
-    success: vi.fn(),
-  },
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
 }));
 
 describe('Home 페이지', () => {
@@ -101,26 +47,30 @@ describe('Home 페이지', () => {
 
   beforeEach(() => {
     mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    localStorage.clear();
   });
 
   afterEach(() => {
     mathRandomSpy.mockRestore();
   });
 
-  it('요즘 인기 차 카드와 공개 차록을 렌더링한다', async () => {
+  it('빠른 접근 버튼과 주간 캘린더를 렌더링한다', async () => {
     renderWithRouter(<Home />, { route: '/' });
 
-    // API 호출이 완료될 때까지 대기 - 로딩 스피너가 사라지고 콘텐츠가 나타날 때까지 기다림
-    await screen.findByText(/요즘 인기 차/, {}, { timeout: 5000 });
-    
-    // 로딩 스피너가 사라졌는지 확인
-    expect(screen.queryByRole('status', { name: /로딩/i })).not.toBeInTheDocument();
-    
-    expect(screen.getByText(/요즘 인기 차/)).toBeInTheDocument();
-    expect(screen.getAllByRole('heading', { name: '화과향' })).toHaveLength(2);
+    await waitFor(() => {
+      expect(screen.getAllByText('차록 쓰기').length).toBeGreaterThan(0);
+    });
 
-    expect(screen.getByText('공개 차록입니다.')).toBeInTheDocument();
-    expect(screen.queryByText('비공개 차록입니다.')).not.toBeInTheDocument();
+    expect(screen.getByText('탐색하기')).toBeInTheDocument();
+    expect(screen.getAllByText('내 차록').length).toBeGreaterThan(0);
+    // 주간 캘린더 요일 표시
+    expect(screen.getAllByText('일').length).toBeGreaterThan(0);
+  });
+
+  it('로그인 시 최근 차록 섹션을 렌더링한다', async () => {
+    renderWithRouter(<Home />, { route: '/' });
+
+    await screen.findByText('최근 차록', {}, { timeout: 5000 });
+    expect(screen.getByText('최근 차록')).toBeInTheDocument();
   });
 });
-

--- a/src/pages/__tests__/Search.test.tsx
+++ b/src/pages/__tests__/Search.test.tsx
@@ -56,6 +56,16 @@ vi.mock('../../lib/api', () => ({
   },
   tagsApi: {
     getPopularTags: vi.fn(() => Promise.resolve(mockPopularTags)),
+    getFollowedTags: vi.fn(() => Promise.resolve([])),
+  },
+  notesApi: {
+    getAll: vi.fn(() => Promise.resolve([])),
+  },
+  usersApi: {
+    getTrending: vi.fn(() => Promise.resolve([])),
+  },
+  cellarApi: {
+    getAll: vi.fn(() => Promise.resolve([])),
   },
 }));
 
@@ -91,14 +101,18 @@ const getNavigateSpy = () => {
 
 describe('Search 페이지', () => {
   it('탐색 섹션(인기, 신규, 맞춤차, 찻집)을 렌더링한다', async () => {
+    const user = userEvent.setup();
     renderWithRouter(<Search />, { route: '/sasaek' });
 
+    const exploreTabButtons = screen.getAllByRole('button', { name: '탐색' });
+    await user.click(exploreTabButtons[exploreTabButtons.length - 1]);
+
     await waitFor(() => {
-      expect(screen.getByText(/사랑받는 차/)).toBeInTheDocument();
+      expect(screen.getAllByText(/사랑받는 차/).length).toBeGreaterThan(0);
     });
-    expect(screen.getByText(/신규 차/)).toBeInTheDocument();
-    expect(screen.getByText(/맞춤차/)).toBeInTheDocument();
-    expect(screen.getByText(/찻집\/다실/)).toBeInTheDocument();
+    expect(screen.getAllByText(/신규 차/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/맞춤차/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/찻집\/다실/).length).toBeGreaterThan(0);
   });
 
   it('검색어와 일치하는 차를 렌더링한다', async () => {
@@ -123,7 +137,11 @@ describe('Search 페이지', () => {
   });
 
   it('찻집/다실 섹션에 찻집 목록을 표시한다', async () => {
+    const user = userEvent.setup();
     renderWithRouter(<Search />, { route: '/sasaek' });
+
+    const exploreTabBtns = screen.getAllByRole('button', { name: '탐색' });
+    await user.click(exploreTabBtns[exploreTabBtns.length - 1]);
 
     await waitFor(() => {
       expect(screen.getByText('탐색전용샵')).toBeInTheDocument();
@@ -170,6 +188,11 @@ describe('Search 페이지', () => {
     await waitFor(() => {
       expect(screen.getByText('필터')).toBeInTheDocument();
     });
-    expect(screen.getByText('인기순')).toBeInTheDocument();
+
+    await user.click(screen.getByText('필터'));
+
+    await waitFor(() => {
+      expect(screen.getByText('인기순')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Closes #207
- Home.tsx: 인기 차/인기 다우/차록 흐름 탭 제거 → 배너(dismissible) + 빠른접근 버튼 3개(차록 쓰기/탐색하기/내 차록) + 주간 미니캘린더 + 내 최근 차록
- Search.tsx 탐색 탭: 인기 다우(CreatorCard 가로 스크롤) 추가 + 차록 흐름 탭(맞춤차/구독/향미) 추가

## Test plan
- [x] npm run build
- [x] npm run test:run (Home/Search 관련 테스트 통과)
- [ ] cd backend && npm run build && npm run test