### PR TITLE
fix: PR #243 코드리뷰 후속 반영

### DIFF
--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1359,6 +1359,16 @@ export class AdminService {
       const type = row['type']?.trim();
       if (!name) { errors.push({ row: rowNum, message: 'name 필드가 비어있습니다.' }); continue; }
       if (!type) { errors.push({ row: rowNum, message: 'type 필드가 비어있습니다.' }); continue; }
+      const priceRaw = row['price']?.trim();
+      const weightRaw = row['weight']?.trim();
+      if (priceRaw) {
+        const p = Number(priceRaw);
+        if (!Number.isInteger(p) || p < 0) { errors.push({ row: rowNum, message: 'price는 0 이상의 정수여야 합니다.' }); continue; }
+      }
+      if (weightRaw) {
+        const w = Number(weightRaw);
+        if (!Number.isInteger(w) || w < 0) { errors.push({ row: rowNum, message: 'weight는 0 이상의 정수여야 합니다.' }); continue; }
+      }
       validRows.push({ row, rowNum, name, type });
     }
 
@@ -1367,11 +1377,15 @@ export class AdminService {
       : [];
     const existingKeys = new Set(existingTeas.map((t) => `${t.name}||${t.type}`));
 
+    const seen = new Set<string>();
     for (const { row, name, type } of validRows) {
       if (existingKeys.has(`${name}||${type}`)) { continue; }
+      const key = `${name}||${type}`;
+      if (seen.has(key)) { continue; }
+      seen.add(key);
 
-      const price = row['price'] ? parseInt(row['price'], 10) : undefined;
-      const weight = row['weight'] ? parseInt(row['weight'], 10) : undefined;
+      const price = row['price']?.trim() ? Number(row['price']?.trim()) : undefined;
+      const weight = row['weight']?.trim() ? Number(row['weight']?.trim()) : undefined;
       toInsert.push({
         name,
         type,

--- a/backend/src/admin/crawling.service.ts
+++ b/backend/src/admin/crawling.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { Injectable, BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Tea } from '../teas/entities/tea.entity';
+import { Seller } from '../teas/entities/seller.entity';
 import * as cheerio from 'cheerio';
 
 export interface CrawlConfig {
@@ -23,6 +24,8 @@ export class CrawlingService {
   constructor(
     @InjectRepository(Tea)
     private teasRepository: Repository<Tea>,
+    @InjectRepository(Seller)
+    private sellersRepository: Repository<Seller>,
   ) {}
 
   private validateUrl(url: string): void {
@@ -92,6 +95,11 @@ export class CrawlingService {
 
   async register(items: TeaCrawlItem[], sellerId?: number): Promise<{ success: number; skipped: number }> {
     if (items.length === 0) return { success: 0, skipped: 0 };
+
+    if (sellerId !== undefined) {
+      const seller = await this.sellersRepository.findOne({ where: { id: sellerId } });
+      if (!seller) throw new NotFoundException(`찻집(id=${sellerId})을 찾을 수 없습니다.`);
+    }
 
     const existingTeas = await this.teasRepository.findBy({ name: In(items.map((i) => i.name)) });
     const existingKeys = new Set(existingTeas.map((t) => `${t.name}||${t.type}`));

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -360,6 +360,8 @@ export class UsersController {
   @Get(':id/level')
   @UseGuards(OptionalJwtAuthGuard)
   getUserLevel(@Param('id') id: string) {
-    return this.userLevelService.getUserLevel(parseInt(id, 10));
+    const parsedId = parseInt(id, 10);
+    if (isNaN(parsedId)) throw new BadRequestException('유효하지 않은 사용자 ID입니다.');
+    return this.userLevelService.getUserLevel(parsedId);
   }
 }

--- a/src/pages/NewPost.tsx
+++ b/src/pages/NewPost.tsx
@@ -72,7 +72,7 @@ export function NewPost() {
     if (!notePickerOpen || myNotes.length > 0 || !user) return;
     notesApi.getAll(user.id, undefined, undefined, undefined, undefined, undefined, 1, 100)
       .then((notes) => setMyNotes(notes.map((n) => ({ id: n.id, teaName: n.teaName, overallRating: n.overallRating }))))
-      .catch(() => {});
+      .catch(() => toast.error('차록 목록을 불러오지 못했습니다.'));
   }, [notePickerOpen, user]);
 
   const toggleNoteTag = (note: Pick<Note, 'id' | 'teaName' | 'overallRating'>) => {

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -257,57 +257,59 @@ export function NoteDetail() {
                 )}
               </Badge>
             </div>
-            {user && (
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={handleLikeClick}
-                  disabled={isTogglingLike}
-                  className={`min-h-[44px] flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${
-                    isLiked 
-                      ? 'text-primary hover:bg-primary/10' 
-                      : 'text-muted-foreground hover:bg-accent'
-                  }`}
-                  title={isLiked ? '좋아요 취소' : '좋아요'}
-                >
-                  <Heart
-                    className={`w-5 h-5 transition-all ${
-                      isLiked 
-                        ? 'fill-primary text-primary stroke-primary' 
-                        : 'fill-none text-muted-foreground stroke-muted-foreground'
+            <div className="flex items-center gap-2">
+              {user && (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleLikeClick}
+                    disabled={isTogglingLike}
+                    className={`min-h-[44px] flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${
+                      isLiked
+                        ? 'text-primary hover:bg-primary/10'
+                        : 'text-muted-foreground hover:bg-accent'
                     }`}
-                  />
-                  {likeCount > 0 && <span className="text-sm font-medium">{likeCount}</span>}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleBookmarkClick}
-                  disabled={isTogglingBookmark}
-                  className={`min-h-[44px] min-w-[44px] flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${
-                    isBookmarked 
-                      ? 'text-primary hover:bg-primary/10' 
-                      : 'text-muted-foreground hover:bg-accent'
-                  }`}
-                  title={isBookmarked ? '북마크 해제' : '북마크 추가'}
-                >
-                  <Bookmark
-                    className={`w-5 h-5 transition-all ${
+                    title={isLiked ? '좋아요 취소' : '좋아요'}
+                  >
+                    <Heart
+                      className={`w-5 h-5 transition-all ${
+                        isLiked
+                          ? 'fill-primary text-primary stroke-primary'
+                          : 'fill-none text-muted-foreground stroke-muted-foreground'
+                      }`}
+                    />
+                    {likeCount > 0 && <span className="text-sm font-medium">{likeCount}</span>}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleBookmarkClick}
+                    disabled={isTogglingBookmark}
+                    className={`min-h-[44px] min-w-[44px] flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${
                       isBookmarked
-                        ? 'fill-primary text-primary stroke-primary'
-                        : 'fill-none text-muted-foreground stroke-muted-foreground'
+                        ? 'text-primary hover:bg-primary/10'
+                        : 'text-muted-foreground hover:bg-accent'
                     }`}
-                  />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => share(tea?.name ?? '차록', window.location.href)}
-                  className="min-h-[44px] min-w-[44px] flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors text-muted-foreground hover:bg-accent"
-                  title="공유하기"
-                >
-                  <Share2 className="w-5 h-5" />
-                </button>
-              </div>
-            )}
+                    title={isBookmarked ? '북마크 해제' : '북마크 추가'}
+                  >
+                    <Bookmark
+                      className={`w-5 h-5 transition-all ${
+                        isBookmarked
+                          ? 'fill-primary text-primary stroke-primary'
+                          : 'fill-none text-muted-foreground stroke-muted-foreground'
+                      }`}
+                    />
+                  </button>
+                </>
+              )}
+              <button
+                type="button"
+                onClick={() => share(tea?.name ?? '차록', window.location.href)}
+                className="min-h-[44px] min-w-[44px] flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-colors text-muted-foreground hover:bg-accent"
+                title="공유하기"
+              >
+                <Share2 className="w-5 h-5" />
+              </button>
+            </div>
 
           </div>
           

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -330,7 +330,7 @@ export function PostDetail() {
                 <button
                   key={note.id}
                   type="button"
-                  onClick={() => navigate(`/notes/${note.id}`)}
+                  onClick={() => navigate(`/note/${note.id}`)}
                   className="flex items-center justify-between px-3 py-2.5 rounded-lg border border-border bg-muted/30 hover:bg-muted/60 transition-colors text-left"
                 >
                   <span className="text-sm font-medium text-foreground">{note.teaName}</span>

--- a/src/pages/admin/AdminMaster.tsx
+++ b/src/pages/admin/AdminMaster.tsx
@@ -412,6 +412,7 @@ export function AdminMaster() {
                   try {
                     const result = await adminApi.bulkUploadTeas(file);
                     setCsvResult(result);
+                    adminApi.getTeas({ search: search || undefined, limit: 50 }).then(setTeas);
                     toast.success(`등록 ${result.success}건 / 스킵 ${result.skipped}건 / 오류 ${result.errors.length}건`);
                   } catch {
                     toast.error('업로드 실패');
@@ -493,6 +494,7 @@ export function AdminMaster() {
                   try {
                     const selected = crawlItems.filter((i) => i.selected).map(({ name, type, price }) => ({ name, type, price }));
                     const r = await adminApi.crawlRegister(selected);
+                    adminApi.getTeas({ search: search || undefined, limit: 50 }).then(setTeas);
                     toast.success(`등록 ${r.success}건 / 스킵 ${r.skipped}건`);
                     setCrawlItems([]);
                   } catch { toast.error('등록 실패'); }


### PR DESCRIPTION
## Summary
PR #243 coderabbitai 리뷰 항목 전체 반영

- **NoteDetail**: 공유 버튼을 `user &&` 블록 밖으로 이동 → 비로그인 사용자도 공개 차록 공유 가능 (#195 기능 정상화)
- **PostDetail**: 태그된 차록 클릭 navigate 경로 `/notes/` → `/note/` 수정 (404 방지)
- **NewPost**: 차록 목록 로드 실패 시 toast 오류 메시지 노출
- **AdminMaster**: CSV 업로드/크롤링 등록 성공 후 차 목록 자동 갱신
- **admin.service**: CSV 동일 파일 내 중복 행 스킵 (`seen` Set 추가)
- **admin.service**: CSV `price`/`weight` 정수 유효성 검증 (잘못된 값 에러 행 처리)
- **crawling.service**: `register()` 시 sellerId 존재 여부 검증 (FK 위반 방지)
- **users.controller**: `GET /:id/level` NaN 입력 시 `BadRequestException` 처리

이미 반영된 항목 (PR #243 브랜치 내):
- SSRF 취약점 (`validateUrl()` 추가)
- N+1 쿼리 (`register`, `bulkUploadTeas`)

## Test plan
- [ ] 비로그인 상태에서 공개 차록 공유 버튼 노출 확인
- [ ] 게시글 태그된 차록 클릭 → 차록 상세 페이지 이동 확인
- [ ] CSV 중복/잘못된 값 업로드 → 에러 행 메시지 확인
- [ ] npm run build
- [ ] cd backend && npm run build && npm run test