### PR TITLE
fix: SpeedDialFAB 포인터 이벤트 차단 수정 및 찜한 차 저장함 탭 이동

### DIFF
--- a/src/components/SpeedDialFAB.tsx
+++ b/src/components/SpeedDialFAB.tsx
@@ -103,7 +103,7 @@ export function SpeedDialFAB() {
 
       {/* Speed Dial 컨테이너 */}
       <div
-        className="fixed right-6 z-50 flex flex-col items-end md:bottom-6"
+        className={cn('fixed right-6 z-50 flex flex-col items-end md:bottom-6', !isOpen && 'pointer-events-none')}
         style={{ bottom: 'calc(var(--bottom-nav-spacer) + 0.75rem)' }}
       >
         {/* 메뉴 아이템 (FAB 위쪽으로 펼침) */}
@@ -155,7 +155,7 @@ export function SpeedDialFAB() {
           aria-label={isOpen ? '메뉴 닫기' : '메뉴 열기'}
           aria-expanded={isOpen}
           onClick={() => setIsOpen((prev) => !prev)}
-          className="w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-[0_2px_12px_rgba(29,185,60,0.35)] flex items-center justify-center transition-all hover:bg-primary/90 hover:shadow-[0_4px_16px_rgba(29,185,60,0.4)] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          className="pointer-events-auto w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-[0_2px_12px_rgba(29,185,60,0.35)] flex items-center justify-center transition-all hover:bg-primary/90 hover:shadow-[0_4px_16px_rgba(29,185,60,0.4)] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         >
           <span
             className={cn(

--- a/src/pages/Saved.tsx
+++ b/src/pages/Saved.tsx
@@ -3,19 +3,20 @@ import { useNavigate } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { NoteCard } from '../components/NoteCard';
 import { PostCard } from '../components/PostCard';
+import { TeaCard } from '../components/TeaCard';
 import { EmptyState } from '../components/EmptyState';
 import { BottomNav } from '../components/BottomNav';
 import { Section } from '../components/ui/Section';
 import { Button } from '../components/ui/button';
-import { notesApi, postsApi } from '../lib/api';
-import { Note, Post } from '../types';
+import { notesApi, postsApi, teasApi } from '../lib/api';
+import { Note, Post, Tea } from '../types';
 import { logger } from '../lib/logger';
 import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '../contexts/AuthContext';
 import { cn } from '../components/ui/utils';
 
-type SavedTab = 'notes' | 'posts';
+type SavedTab = 'notes' | 'posts' | 'teas';
 const PAGE_SIZE = 20;
 
 export function Saved() {
@@ -32,6 +33,8 @@ export function Saved() {
   const [postsPage, setPostsPage] = useState(1);
   const [postsHasMore, setPostsHasMore] = useState(true);
   const [isLoadingMorePosts, setIsLoadingMorePosts] = useState(false);
+  const [wishlistedTeas, setWishlistedTeas] = useState<Tea[]>([]);
+  const [isLoadingTeas, setIsLoadingTeas] = useState(false);
 
   const displayedNotes = useMemo(
     () => bookmarkedNotes.slice(0, notesDisplayCount),
@@ -71,6 +74,20 @@ export function Saved() {
     }
   }, [user]);
 
+  const fetchWishlistedTeas = useCallback(async () => {
+    if (!user) return;
+    try {
+      setIsLoadingTeas(true);
+      const teas = await teasApi.getWishlisted();
+      setWishlistedTeas(Array.isArray(teas) ? teas : []);
+    } catch (error) {
+      logger.error('Failed to fetch wishlisted teas:', error);
+      toast.error('찜한 차를 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoadingTeas(false);
+    }
+  }, [user]);
+
   const handleLoadMorePosts = useCallback(async () => {
     if (!user) return;
     const nextPage = postsPage + 1;
@@ -101,15 +118,20 @@ export function Saved() {
     if (activeTab === 'posts' && user) {
       fetchBookmarkedPosts();
     }
-  }, [activeTab, user, fetchBookmarkedPosts]);
+    if (activeTab === 'teas' && user) {
+      fetchWishlistedTeas();
+    }
+  }, [activeTab, user, fetchBookmarkedPosts, fetchWishlistedTeas]);
 
   const handleRefresh = useCallback(() => {
     if (activeTab === 'notes') {
       fetchBookmarkedNotes();
-    } else {
+    } else if (activeTab === 'posts') {
       fetchBookmarkedPosts();
+    } else {
+      fetchWishlistedTeas();
     }
-  }, [activeTab, fetchBookmarkedNotes, fetchBookmarkedPosts]);
+  }, [activeTab, fetchBookmarkedNotes, fetchBookmarkedPosts, fetchWishlistedTeas]);
 
   const handleNoteBookmarkRemoved = (noteId: number) => {
     setBookmarkedNotes(prev => prev.filter(n => n.id !== noteId));
@@ -155,6 +177,17 @@ export function Saved() {
             )}
           >
             게시글
+          </button>
+          <button
+            onClick={() => setActiveTab('teas')}
+            className={cn(
+              'px-4 py-2 rounded-full text-sm font-medium transition-colors',
+              activeTab === 'teas'
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+            )}
+          >
+            찜한 차
           </button>
         </div>
       </div>
@@ -242,6 +275,28 @@ export function Saved() {
                 type="feed"
                 message="아직 저장한 게시글이 없어요."
                 action={{ label: '차담 보기', onClick: () => navigate('/chadam') }}
+              />
+            )}
+          </Section>
+        )}
+
+        {activeTab === 'teas' && (
+          <Section title="찜한 차" spacing="lg">
+            {isLoadingTeas ? (
+              <div className="flex justify-center py-8">
+                <Loader2 className="w-8 h-8 text-primary animate-spin" role="status" aria-label="로딩 중" />
+              </div>
+            ) : wishlistedTeas.length > 0 ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {wishlistedTeas.map(tea => (
+                  <TeaCard key={tea.id} tea={tea} />
+                ))}
+              </div>
+            ) : (
+              <EmptyState
+                type="search"
+                message="아직 찜한 차가 없어요."
+                action={{ label: '차 탐색하기', onClick: () => navigate('/sasaek') }}
               />
             )}
           </Section>

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { NoteCard } from '../components/NoteCard';
-import { TeaCard } from '../components/TeaCard';
+
 import { EmptyState } from '../components/EmptyState';
 import {
   Select,
@@ -12,8 +12,8 @@ import {
   SelectValue,
 } from '../components/ui/select';
 import { BottomNav } from '../components/BottomNav';
-import { usersApi, notesApi, followsApi, teasApi } from '../lib/api';
-import { User, Note, UserOnboardingPreference, Tea, UserLevel } from '../types';
+import { usersApi, notesApi, followsApi } from '../lib/api';
+import { User, Note, UserOnboardingPreference, UserLevel } from '../types';
 import { toast } from 'sonner';
 import { Loader2, Star, Heart, FileText, Camera, Instagram, Globe, Pencil, Bookmark, BarChart2 } from 'lucide-react';
 import { logger } from '../lib/logger';
@@ -53,7 +53,7 @@ export function UserProfile() {
   const [onboardingPreference, setOnboardingPreference] = useState<UserOnboardingPreference | null>(null);
 
   const isOwnProfile = !authLoading && currentUser && userId === currentUser.id;
-  const [wishlistedTeas, setWishlistedTeas] = useState<Tea[]>([]);
+
   const [isPrivateProfile, setIsPrivateProfile] = useState(false);
 
   const initialLoadDone = useRef(false);
@@ -105,9 +105,6 @@ export function UserProfile() {
       setOnboardingPreference(pref);
       initialLoadDone.current = true;
 
-      if (isOwnProfile) {
-        teasApi.getWishlisted().then((teas) => setWishlistedTeas(Array.isArray(teas) ? teas : [])).catch(() => {});
-      }
     } catch (error: unknown) {
       logger.error('Failed to fetch user profile:', error);
       const statusCode = (error as { statusCode?: number })?.statusCode;
@@ -564,25 +561,6 @@ export function UserProfile() {
               </SelectContent>
             </Select>
           </div>
-        )}
-
-        {/* 찜한 차 섹션 - 내 프로필에서만 표시 */}
-        {isOwnProfile && (
-          <Section title="찜한 차" spacing="lg">
-            {wishlistedTeas.length > 0 ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                {wishlistedTeas.map((tea) => (
-                  <TeaCard key={tea.id} tea={tea} />
-                ))}
-              </div>
-            ) : (
-              <EmptyState
-                type="search"
-                message="아직 찜한 차가 없어요."
-                action={{ label: '차 탐색하기', onClick: () => navigate('/sasaek') }}
-              />
-            )}
-          </Section>
         )}
 
         {/* 노트 목록 섹션 */}


### PR DESCRIPTION
## Summary
- SpeedDialFAB가 닫힌 상태에서 우측 하단 영역의 클릭/스크롤을 차단하던 버그 수정 (pointer-events-none)
- 찜한 차 섹션을 UserProfile에서 제거하고 저장함 페이지의 세 번째 탭으로 이동
- 저장함 페이지: 차록 / 게시글 / 찜한 차 3탭 구성

## Test plan
- [ ] 모바일에서 SpeedDialFAB 닫힌 상태로 우측 하단 버튼(레포트, 저장함) 클릭 가능 확인
- [ ] 모바일에서 우측 영역 스크롤 정상 동작 확인
- [ ] 저장함 페이지에서 차록/게시글/찜한 차 탭 전환 정상 동작 확인
- [ ] UserProfile에서 찜한 차 섹션이 제거되었는지 확인
- [ ] npm run build
- [ ] npm run test:run

🤖 Generated with [Claude Code](https://claude.com/claude-code)