### PR TITLE
chore: #220 누락 테스트 코드 추가

### DIFF
--- a/backend/src/teas/seller.service.spec.ts
+++ b/backend/src/teas/seller.service.spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
+import { SellerService } from './seller.service';
+import { Seller } from './entities/seller.entity';
+import { Tea } from './entities/tea.entity';
+
+const mockSellerRepository = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+};
+
+const mockTeasRepository = {
+  find: jest.fn(),
+};
+
+const mockDataSource = {
+  query: jest.fn(),
+};
+
+const makeSeller = (overrides: Partial<Seller> = {}): Seller =>
+  ({
+    id: 1,
+    name: '이도다원',
+    address: null,
+    mapUrl: null,
+    websiteUrl: null,
+    phone: null,
+    description: null,
+    businessHours: null,
+    ...overrides,
+  }) as Seller;
+
+describe('SellerService', () => {
+  let service: SellerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SellerService,
+        { provide: getRepositoryToken(Seller), useValue: mockSellerRepository },
+        { provide: getRepositoryToken(Tea), useValue: mockTeasRepository },
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<SellerService>(SellerService);
+    jest.clearAllMocks();
+  });
+
+  describe('createSeller', () => {
+    it('빈 이름 → Error throw', async () => {
+      await expect(service.createSeller({ name: '   ' })).rejects.toThrow('찻집 이름을 입력해주세요.');
+    });
+
+    it('이미 존재하는 이름(추가 필드 없음) → 기존 seller 반환', async () => {
+      const existing = makeSeller();
+      mockSellerRepository.findOne.mockResolvedValue(existing);
+
+      const result = await service.createSeller({ name: '이도다원' });
+
+      expect(mockSellerRepository.save).not.toHaveBeenCalled();
+      expect(result).toEqual(existing);
+    });
+
+    it('이미 존재하는 이름 + 추가 필드 → 업데이트 후 반환', async () => {
+      const existing = makeSeller();
+      mockSellerRepository.findOne.mockResolvedValue(existing);
+      mockSellerRepository.save.mockResolvedValue({ ...existing, address: '서울시 종로구' });
+
+      const result = await service.createSeller({ name: '이도다원', address: '서울시 종로구' });
+
+      expect(mockSellerRepository.save).toHaveBeenCalled();
+      expect(result.address).toBe('서울시 종로구');
+    });
+
+    it('신규 이름 → seller 생성 후 반환', async () => {
+      mockSellerRepository.findOne.mockResolvedValue(null);
+      const newSeller = makeSeller({ id: 2, name: '차향다원' });
+      mockSellerRepository.create.mockReturnValue(newSeller);
+      mockSellerRepository.save.mockResolvedValue(newSeller);
+
+      const result = await service.createSeller({ name: '차향다원' });
+
+      expect(mockSellerRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: '차향다원' }),
+      );
+      expect(result.name).toBe('차향다원');
+    });
+
+    it('중복 키 에러(ER_DUP_ENTRY) 시 기존 seller 반환', async () => {
+      mockSellerRepository.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(makeSeller());
+      mockSellerRepository.create.mockReturnValue(makeSeller());
+      const dupError = Object.assign(new Error('dup'), { code: 'ER_DUP_ENTRY' });
+      mockSellerRepository.save.mockRejectedValue(dupError);
+
+      const result = await service.createSeller({ name: '이도다원' });
+
+      expect(result).toEqual(makeSeller());
+    });
+  });
+
+  describe('findSellerByName', () => {
+    it('이름으로 seller 조회', async () => {
+      const seller = makeSeller();
+      mockSellerRepository.findOne.mockResolvedValue(seller);
+
+      const result = await service.findSellerByName('이도다원');
+
+      expect(mockSellerRepository.findOne).toHaveBeenCalledWith({ where: { name: '이도다원' } });
+      expect(result).toEqual(seller);
+    });
+
+    it('존재하지 않으면 null 반환', async () => {
+      mockSellerRepository.findOne.mockResolvedValue(null);
+      const result = await service.findSellerByName('없는다원');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateSeller', () => {
+    it('존재하지 않는 seller → null 반환', async () => {
+      mockSellerRepository.findOne.mockResolvedValue(null);
+      const result = await service.updateSeller('없는다원', { address: '서울' });
+      expect(result).toBeNull();
+    });
+
+    it('존재하는 seller → 필드 업데이트 후 반환', async () => {
+      const seller = makeSeller();
+      mockSellerRepository.findOne.mockResolvedValue(seller);
+      mockSellerRepository.save.mockResolvedValue({ ...seller, address: '서울시 강남구' });
+
+      const result = await service.updateSeller('이도다원', { address: '서울시 강남구' });
+
+      expect(mockSellerRepository.save).toHaveBeenCalled();
+      expect(result?.address).toBe('서울시 강남구');
+    });
+
+    it('빈 문자열 address → null 저장', async () => {
+      const seller = makeSeller({ address: '기존주소' });
+      mockSellerRepository.findOne.mockResolvedValue(seller);
+      mockSellerRepository.save.mockResolvedValue({ ...seller, address: null });
+
+      const result = await service.updateSeller('이도다원', { address: '' });
+
+      expect(result?.address).toBeNull();
+    });
+  });
+
+  describe('findSellers', () => {
+    it('차와 연결된 seller 목록 반환', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([{ name: '이도다원', teaCount: '5' }])
+        .mockResolvedValueOnce([{ name: '이도다원' }, { name: '차향다원' }]);
+
+      const result = await service.findSellers();
+
+      expect(result[0].name).toBe('이도다원');
+      expect(result[0].teaCount).toBe(5);
+      expect(result.some((s) => s.name === '차향다원')).toBe(true);
+    });
+
+    it('sellers 테이블 조회 실패 시 fromTeas만 반환', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([{ name: '이도다원', teaCount: '3' }])
+        .mockRejectedValueOnce(new Error('DB error'));
+
+      const result = await service.findSellers();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('이도다원');
+    });
+  });
+
+  describe('findSellersByQuery', () => {
+    it('쿼리로 seller 검색', async () => {
+      mockDataSource.query
+        .mockResolvedValueOnce([{ name: '이도다원', teaCount: '5' }])
+        .mockResolvedValueOnce([{ name: '이도다원' }]);
+
+      const result = await service.findSellersByQuery('이도');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('이도다원');
+    });
+
+    it('결과 최대 20개 제한', async () => {
+      const rows = Array.from({ length: 25 }, (_, i) => ({ name: `다원${i}`, teaCount: '1' }));
+      mockDataSource.query.mockResolvedValueOnce(rows).mockResolvedValueOnce([]);
+
+      const result = await service.findSellersByQuery('다원');
+
+      expect(result.length).toBeLessThanOrEqual(20);
+    });
+  });
+
+  describe('findBySeller', () => {
+    it('존재하지 않는 seller → 빈 배열 반환', async () => {
+      mockSellerRepository.findOne.mockResolvedValue(null);
+      const result = await service.findBySeller('없는다원');
+      expect(result).toEqual([]);
+    });
+
+    it('존재하는 seller → 해당 seller의 차 목록 반환', async () => {
+      const seller = makeSeller();
+      mockSellerRepository.findOne.mockResolvedValue(seller);
+      const teas = [{ id: 1, name: '화과향', seller } as Tea];
+      mockTeasRepository.find.mockResolvedValue(teas);
+
+      const result = await service.findBySeller('이도다원');
+
+      expect(mockTeasRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { seller: { id: seller.id } } }),
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/backend/src/teas/tea-recommendation.service.spec.ts
+++ b/backend/src/teas/tea-recommendation.service.spec.ts
@@ -1,0 +1,234 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { TeaRecommendationService } from './tea-recommendation.service';
+import { Tea } from './entities/tea.entity';
+import { UsersService } from '../users/users.service';
+import { TeaAnalyticsService } from './tea-analytics.service';
+
+const mockTeasRepository = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+const mockDataSource = {
+  query: jest.fn(),
+};
+
+const mockUsersService = {
+  getOnboardingPreference: jest.fn(),
+};
+
+const mockTeaAnalyticsService = {
+  getPopularTags: jest.fn(),
+};
+
+const makeTea = (overrides: Partial<Tea> = {}): Tea =>
+  ({
+    id: 1,
+    name: '화과향',
+    type: '백차',
+    averageRating: 4.5,
+    reviewCount: 20,
+    createdAt: new Date('2024-01-01'),
+    ...overrides,
+  }) as Tea;
+
+describe('TeaRecommendationService', () => {
+  let service: TeaRecommendationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TeaRecommendationService,
+        { provide: getRepositoryToken(Tea), useValue: mockTeasRepository },
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: TeaAnalyticsService, useValue: mockTeaAnalyticsService },
+      ],
+    }).compile();
+
+    service = module.get<TeaRecommendationService>(TeaRecommendationService);
+    jest.clearAllMocks();
+  });
+
+  describe('findPopularTeas', () => {
+    it('reviewCount DESC 순으로 차 목록 반환', async () => {
+      const teas = [makeTea({ id: 1, reviewCount: 20 }), makeTea({ id: 2, reviewCount: 10 })];
+      mockTeasRepository.find.mockResolvedValue(teas);
+
+      const result = await service.findPopularTeas(2);
+
+      expect(mockTeasRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: { reviewCount: 'DESC', averageRating: 'DESC', id: 'ASC' },
+          take: 2,
+        }),
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it('limit 50 초과 시 50으로 clamp', async () => {
+      mockTeasRepository.find.mockResolvedValue([]);
+      await service.findPopularTeas(100);
+      expect(mockTeasRepository.find).toHaveBeenCalledWith(expect.objectContaining({ take: 50 }));
+    });
+
+    it('limit 0 이하 시 1로 clamp', async () => {
+      mockTeasRepository.find.mockResolvedValue([]);
+      await service.findPopularTeas(0);
+      expect(mockTeasRepository.find).toHaveBeenCalledWith(expect.objectContaining({ take: 1 }));
+    });
+  });
+
+  describe('findNewTeas', () => {
+    it('createdAt DESC 순으로 차 목록 반환', async () => {
+      const teas = [makeTea({ id: 2, createdAt: new Date('2024-06-01') })];
+      mockTeasRepository.find.mockResolvedValue(teas);
+
+      const result = await service.findNewTeas(1);
+
+      expect(mockTeasRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: { createdAt: 'DESC', id: 'ASC' },
+          take: 1,
+        }),
+      );
+      expect(result).toEqual(teas);
+    });
+  });
+
+  describe('getSimilarTeas', () => {
+    it('존재하지 않는 차 ID → NotFoundException', async () => {
+      mockTeasRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getSimilarTeas(999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('같은 type의 차들을 반환 (빌더 체인)', async () => {
+      const tea = makeTea({ id: 1, type: '백차', averageRating: 4.5 });
+      mockTeasRepository.findOne.mockResolvedValue(tea);
+
+      const mockQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([makeTea({ id: 2, type: '백차' })]),
+      };
+      mockTeasRepository.createQueryBuilder.mockReturnValue(mockQb);
+
+      const result = await service.getSimilarTeas(1);
+
+      expect(mockQb.where).toHaveBeenCalledWith('tea.type = :type', { type: '백차' });
+      expect(mockQb.andWhere).toHaveBeenCalledWith('tea.id != :id', { id: 1 });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('findCurationTeas', () => {
+    it('userId 없을 때 popular+new 혼합 반환', async () => {
+      const popularTeas = [makeTea({ id: 1 }), makeTea({ id: 2 })];
+      const newTeas = [makeTea({ id: 3 })];
+      mockTeasRepository.find
+        .mockResolvedValueOnce(popularTeas)
+        .mockResolvedValueOnce(newTeas);
+
+      const result = await service.findCurationTeas(3);
+
+      expect(result).toHaveLength(3);
+      const ids = result.map((t) => t.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('userId 있고 onboarding 완료 + 선호 타입 있을 때 타입 기반 쿼리', async () => {
+      mockUsersService.getOnboardingPreference.mockResolvedValue({
+        hasCompletedOnboarding: true,
+        preferredTeaTypes: ['백차', '녹차'],
+      });
+
+      const mockQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([makeTea({ id: 1 }), makeTea({ id: 2 })]),
+      };
+      mockTeasRepository.createQueryBuilder.mockReturnValue(mockQb);
+
+      const result = await service.findCurationTeas(2, 1);
+
+      expect(mockUsersService.getOnboardingPreference).toHaveBeenCalledWith(1);
+      expect(result).toHaveLength(2);
+    });
+
+    it('onboarding 미완료 시 popular+new 혼합', async () => {
+      mockUsersService.getOnboardingPreference.mockResolvedValue({
+        hasCompletedOnboarding: false,
+        preferredTeaTypes: [],
+      });
+      mockTeasRepository.find.mockResolvedValue([makeTea()]);
+
+      const result = await service.findCurationTeas(5, 1);
+
+      expect(result.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('findTeasByTags', () => {
+    it('빈 태그 배열 → 빈 배열 반환 (DB 미조회)', async () => {
+      const result = await service.findTeasByTags({ tags: [] });
+      expect(result).toEqual([]);
+      expect(mockDataSource.query).not.toHaveBeenCalled();
+    });
+
+    it('태그 있을 때 dataSource.query 호출', async () => {
+      mockDataSource.query.mockResolvedValue([
+        { id: 1, name: '화과향', type: '백차', averageRating: '4.5', reviewCount: '20', createdAt: new Date(), updatedAt: new Date(), sellerName: null },
+      ]);
+
+      const result = await service.findTeasByTags({ tags: ['꽃향'], sort: 'match', limit: 10 });
+
+      expect(mockDataSource.query).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].averageRating).toBe(4.5);
+    });
+
+    it('limit 100 초과 시 100으로 clamp', async () => {
+      mockDataSource.query.mockResolvedValue([]);
+      await service.findTeasByTags({ tags: ['꽃향'], limit: 200 });
+      const callArgs = mockDataSource.query.mock.calls[0][1] as number[];
+      expect(callArgs[callArgs.length - 1]).toBe(100);
+    });
+  });
+
+  describe('getSimilarTeasByTags', () => {
+    it('태그 없으면 getSimilarTeas 결과로 fallback', async () => {
+      mockTeaAnalyticsService.getPopularTags.mockResolvedValue({ tags: [] });
+      const tea = makeTea({ id: 1, type: '백차', averageRating: 4.5 });
+      mockTeasRepository.findOne.mockResolvedValue(tea);
+
+      const mockQb = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([makeTea({ id: 2 })]),
+      };
+      mockTeasRepository.createQueryBuilder.mockReturnValue(mockQb);
+
+      const result = await service.getSimilarTeasByTags(1);
+
+      expect(mockTeaAnalyticsService.getPopularTags).toHaveBeenCalledWith(1);
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/backend/src/users/user-level.service.spec.ts
+++ b/backend/src/users/user-level.service.spec.ts
@@ -1,0 +1,159 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { UserLevelService } from './user-level.service';
+
+const mockDataSource = {
+  query: jest.fn(),
+};
+
+describe('UserLevelService', () => {
+  let service: UserLevelService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserLevelService,
+        {
+          provide: getDataSourceToken(),
+          useValue: mockDataSource,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserLevelService>(UserLevelService);
+    jest.clearAllMocks();
+  });
+
+  function setupQueryMocks(noteCount: number, postCount: number, cellarCount: number, teaTypeCount: number) {
+    mockDataSource.query
+      .mockResolvedValueOnce([{ cnt: String(noteCount) }])
+      .mockResolvedValueOnce([{ cnt: String(postCount) }])
+      .mockResolvedValueOnce([{ cnt: String(cellarCount) }])
+      .mockResolvedValueOnce([{ cnt: String(teaTypeCount) }]);
+  }
+
+  describe('getUserLevel', () => {
+    it('차록 0개 → noteLevel 1(입문), nextThreshold 5', async () => {
+      setupQueryMocks(0, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.noteLevel.level).toBe(1);
+      expect(result.noteLevel.name).toBe('입문');
+      expect(result.noteLevel.nextThreshold).toBe(5);
+      expect(result.noteLevel.count).toBe(0);
+    });
+
+    it('차록 5개 → noteLevel 2(수련)', async () => {
+      setupQueryMocks(5, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.noteLevel.level).toBe(2);
+      expect(result.noteLevel.name).toBe('수련');
+    });
+
+    it('차록 20개 → noteLevel 3(숙련)', async () => {
+      setupQueryMocks(20, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.noteLevel.level).toBe(3);
+      expect(result.noteLevel.name).toBe('숙련');
+    });
+
+    it('차록 50개 → noteLevel 4(마스터), nextThreshold null', async () => {
+      setupQueryMocks(50, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.noteLevel.level).toBe(4);
+      expect(result.noteLevel.name).toBe('마스터');
+      expect(result.noteLevel.nextThreshold).toBeNull();
+    });
+
+    it('게시글 0개 → postLevel 1(새싹)', async () => {
+      setupQueryMocks(0, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.postLevel.level).toBe(1);
+      expect(result.postLevel.name).toBe('새싹');
+    });
+
+    it('게시글 5개 → postLevel 2(이웃)', async () => {
+      setupQueryMocks(0, 5, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.postLevel.level).toBe(2);
+      expect(result.postLevel.name).toBe('이웃');
+    });
+
+    it('게시글 20개 → postLevel 3(단골)', async () => {
+      setupQueryMocks(0, 20, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.postLevel.level).toBe(3);
+      expect(result.postLevel.name).toBe('단골');
+    });
+
+    it('게시글 50개 → postLevel 4(터줏대감)', async () => {
+      setupQueryMocks(0, 50, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.postLevel.level).toBe(4);
+      expect(result.postLevel.name).toBe('터줏대감');
+    });
+
+    it('찻장 0개 → cellarLevel 1(비어있음)', async () => {
+      setupQueryMocks(0, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.cellarLevel.level).toBe(1);
+      expect(result.cellarLevel.name).toBe('비어있음');
+    });
+
+    it('찻장 15개 → cellarLevel 3(수집가)', async () => {
+      setupQueryMocks(0, 0, 15, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.cellarLevel.level).toBe(3);
+      expect(result.cellarLevel.name).toBe('수집가');
+    });
+  });
+
+  describe('badges (computeBadges)', () => {
+    it('차록 1개 이상 → 첫 차록 배지', async () => {
+      setupQueryMocks(1, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.badges.some((b) => b.id === 'first_note')).toBe(true);
+    });
+
+    it('차록 0개 → 첫 차록 배지 없음', async () => {
+      setupQueryMocks(0, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.badges.some((b) => b.id === 'first_note')).toBe(false);
+    });
+
+    it('차록 10개 → note_10 배지', async () => {
+      setupQueryMocks(10, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.badges.some((b) => b.id === 'note_10')).toBe(true);
+    });
+
+    it('차록 50개 → note_50 배지', async () => {
+      setupQueryMocks(50, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.badges.some((b) => b.id === 'note_50')).toBe(true);
+    });
+
+    it('게시글 1개 → first_post 배지', async () => {
+      setupQueryMocks(0, 1, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.badges.some((b) => b.id === 'first_post')).toBe(true);
+    });
+
+    it('찻장 10개 → cellar_10 배지', async () => {
+      setupQueryMocks(0, 0, 10, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.badges.some((b) => b.id === 'cellar_10')).toBe(true);
+    });
+
+    it('차 종류 5가지 → variety_5 배지', async () => {
+      setupQueryMocks(0, 0, 0, 5);
+      const result = await service.getUserLevel(1);
+      expect(result.badges.some((b) => b.id === 'variety_5')).toBe(true);
+    });
+
+    it('모든 조건 미충족 → 빈 배지 배열', async () => {
+      setupQueryMocks(0, 0, 0, 0);
+      const result = await service.getUserLevel(1);
+      expect(result.badges).toHaveLength(0);
+    });
+  });
+});

--- a/src/components/__tests__/BottomNav.test.tsx
+++ b/src/components/__tests__/BottomNav.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { BottomNav } from '../BottomNav';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../MoreMenu', () => ({
+  MoreMenu: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="more-menu">더보기 메뉴</div> : null,
+}));
+
+function renderBottomNav(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <BottomNav />
+    </MemoryRouter>,
+  );
+}
+
+describe('BottomNav', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('5개 내비게이션 버튼(홈, 차담, 내 차록, 찻장, 더보기) 렌더링', () => {
+    renderBottomNav();
+    expect(screen.getByRole('button', { name: '홈' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '차담' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '내 차록' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '찻장' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '더보기' })).toBeInTheDocument();
+  });
+
+  it('홈 버튼 클릭 → navigate 호출 안 함 (이미 / 에 있음)', () => {
+    renderBottomNav('/');
+    fireEvent.click(screen.getByRole('button', { name: '홈' }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('차담 버튼 클릭 → /chadam 으로 navigate', () => {
+    renderBottomNav('/');
+    fireEvent.click(screen.getByRole('button', { name: '차담' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/chadam');
+  });
+
+  it('내 차록 버튼 클릭 → /my-notes 로 navigate', () => {
+    renderBottomNav('/');
+    fireEvent.click(screen.getByRole('button', { name: '내 차록' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/my-notes');
+  });
+
+  it('찻장 버튼 클릭 → /cellar 로 navigate', () => {
+    renderBottomNav('/');
+    fireEvent.click(screen.getByRole('button', { name: '찻장' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/cellar');
+  });
+
+  it('더보기 버튼 클릭 → MoreMenu 열림', () => {
+    renderBottomNav('/');
+    fireEvent.click(screen.getByRole('button', { name: '더보기' }));
+    expect(screen.getByTestId('more-menu')).toBeInTheDocument();
+  });
+
+  it('/chadam 경로에서 차담 버튼이 활성 색상', () => {
+    renderBottomNav('/chadam');
+    const btn = screen.getByRole('button', { name: '차담' });
+    expect(btn.className).toContain('text-primary');
+  });
+
+  it('/my-notes 경로에서 내 차록 버튼이 활성', () => {
+    renderBottomNav('/my-notes');
+    const btn = screen.getByRole('button', { name: '내 차록' });
+    expect(btn.className).toContain('text-primary');
+  });
+});

--- a/src/hooks/__tests__/useNoteForm.test.ts
+++ b/src/hooks/__tests__/useNoteForm.test.ts
@@ -1,0 +1,165 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useNoteForm } from '../useNoteForm';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../lib/api', () => ({
+  notesApi: {
+    getActiveSchemas: vi.fn(() =>
+      Promise.resolve({
+        schemas: [{ id: 1, code: 'standard', version: '1', nameKo: '기본', nameEn: 'Standard' }],
+        pinnedSchemaIds: [1],
+      }),
+    ),
+    getSchemaAxes: vi.fn(() =>
+      Promise.resolve([
+        { id: 10, schemaId: 1, code: 'richness', nameKo: '풍부함', nameEn: 'Richness', displayOrder: 1, minValue: 1, maxValue: 5 },
+      ]),
+    ),
+    getById: vi.fn(),
+    create: vi.fn(() => Promise.resolve({ id: 99 })),
+    update: vi.fn(() => Promise.resolve({ id: 1 })),
+  },
+}));
+
+vi.mock('../../contexts/AuthContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../contexts/AuthContext')>();
+  return {
+    ...actual,
+    useAuth: () => ({
+      isAuthenticated: true,
+      user: { id: 1, name: '김차인', email: 'test@example.com' },
+      isLoading: false,
+    }),
+  };
+});
+
+vi.mock('../../hooks/useTeaSelector', () => ({
+  useTeaSelector: () => ({
+    selectedTea: null,
+    selectTea: vi.fn(),
+    clearTea: vi.fn(),
+    searchQuery: '',
+    setSearchQuery: vi.fn(),
+    searchResults: [],
+    isSearching: false,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('../../lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe('useNoteForm - new 모드', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('초기 상태: overallRating null, memo 빈 문자열, isPublic false', () => {
+    const { result } = renderHook(() =>
+      useNoteForm({ mode: 'new' }),
+    );
+    expect(result.current.overallRating).toBeNull();
+    expect(result.current.memo).toBe('');
+    expect(result.current.isPublic).toBe(false);
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('setMemo 호출 시 memo 상태 업데이트', () => {
+    const { result } = renderHook(() => useNoteForm({ mode: 'new' }));
+    act(() => {
+      result.current.setMemo('좋은 차였습니다.');
+    });
+    expect(result.current.memo).toBe('좋은 차였습니다.');
+  });
+
+  it('setOverallRating 호출 시 overallRating 업데이트', () => {
+    const { result } = renderHook(() => useNoteForm({ mode: 'new' }));
+    act(() => {
+      result.current.setOverallRating(4.5);
+    });
+    expect(result.current.overallRating).toBe(4.5);
+  });
+
+  it('setIsPublic 호출 시 isPublic 업데이트', () => {
+    const { result } = renderHook(() => useNoteForm({ mode: 'new' }));
+    act(() => {
+      result.current.setIsPublic(true);
+    });
+    expect(result.current.isPublic).toBe(true);
+  });
+
+  it('차 미선택 시 handleSave → toast.error 호출', async () => {
+    const { toast } = await import('sonner');
+    const { result } = renderHook(() => useNoteForm({ mode: 'new' }));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('isSampleMode true 시 handleSave → 체험 완료 toast', async () => {
+    const { toast } = await import('sonner');
+    const { result } = renderHook(() => useNoteForm({ mode: 'new', isSampleMode: true }));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('체험 완료'));
+  });
+
+  it('setImagesAndThumbnails 호출 시 images/imageThumbnails 업데이트', () => {
+    const { result } = renderHook(() => useNoteForm({ mode: 'new' }));
+    act(() => {
+      result.current.setImagesAndThumbnails(['img1.jpg'], [null]);
+    });
+    expect(result.current.images).toEqual(['img1.jpg']);
+    expect(result.current.imageThumbnails).toEqual([null]);
+  });
+
+  it('overallRating 설정 시 스키마 fetch 시작', async () => {
+    const { notesApi } = await import('../../lib/api');
+    const { result } = renderHook(() => useNoteForm({ mode: 'new' }));
+
+    act(() => {
+      result.current.setOverallRating(4);
+    });
+
+    await waitFor(() => {
+      expect(notesApi.getActiveSchemas).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('useNoteForm - edit 모드', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('edit 모드 초기 상태: isLoading true', () => {
+    const { result } = renderHook(() => useNoteForm({ mode: 'edit', noteId: 1 }));
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/usePostForm.test.ts
+++ b/src/hooks/__tests__/usePostForm.test.ts
@@ -1,0 +1,130 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { usePostForm } from '../usePostForm';
+import React from 'react';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../lib/api', () => ({
+  postsApi: {
+    create: vi.fn(() => Promise.resolve({ id: 42 })),
+    update: vi.fn(() => Promise.resolve({ id: 1 })),
+    getById: vi.fn(),
+  },
+}));
+
+vi.mock('../../contexts/AuthContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../contexts/AuthContext')>();
+  return {
+    ...actual,
+    useAuth: () => ({
+      user: { id: 1, name: '김차인', email: 'test@example.com' },
+      isAdmin: false,
+    }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe('usePostForm - new 모드', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('초기 상태: title 빈 문자열, content 빈 문자열, category brewing_question', () => {
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+    expect(result.current.title).toBe('');
+    expect(result.current.content).toBe('');
+    expect(result.current.category).toBe('brewing_question');
+    expect(result.current.isAnonymous).toBe(false);
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('setTitle 호출 시 title 상태 업데이트', () => {
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+    act(() => {
+      result.current.setTitle('차 추천 부탁드립니다');
+    });
+    expect(result.current.title).toBe('차 추천 부탁드립니다');
+  });
+
+  it('setContent 호출 시 content 상태 업데이트', () => {
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+    act(() => {
+      result.current.setContent('내용입니다.');
+    });
+    expect(result.current.content).toBe('내용입니다.');
+  });
+
+  it('setCategory 호출 시 category 상태 업데이트', () => {
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+    act(() => {
+      result.current.setCategory('tea_review');
+    });
+    expect(result.current.category).toBe('tea_review');
+  });
+
+  it('setIsAnonymous 호출 시 isAnonymous 상태 업데이트', () => {
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+    act(() => {
+      result.current.setIsAnonymous(true);
+    });
+    expect(result.current.isAnonymous).toBe(true);
+  });
+
+  it('제목/내용 없이 submit → toast.error 호출', async () => {
+    const { toast } = await import('sonner');
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as React.FormEvent);
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('제목과 내용을 입력해주세요.');
+  });
+
+  it('제목/내용 입력 후 submit → postsApi.create 호출 및 navigate', async () => {
+    const { postsApi } = await import('../../lib/api');
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+
+    act(() => {
+      result.current.setTitle('테스트 제목');
+      result.current.setContent('테스트 내용입니다.');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as React.FormEvent);
+    });
+
+    expect(postsApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ title: '테스트 제목', content: '테스트 내용입니다.' }),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/chadam/42', { replace: true });
+  });
+
+  it('selectedGroup, setSelectedGroup 상태 업데이트', () => {
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+    act(() => {
+      result.current.setSelectedGroup('review');
+    });
+    expect(result.current.selectedGroup).toBe('review');
+  });
+
+  it('isLoadingPost: new 모드는 false', () => {
+    const { result } = renderHook(() => usePostForm({ mode: 'new' }));
+    expect(result.current.isLoadingPost).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useSearchFilters.test.ts
+++ b/src/hooks/__tests__/useSearchFilters.test.ts
@@ -1,0 +1,201 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSearchFilters } from '../useSearchFilters';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+vi.mock('../../lib/api', () => ({
+  teasApi: {
+    getWithFilters: vi.fn(() => Promise.resolve([])),
+    getByTags: vi.fn(() => Promise.resolve([])),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('../../lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+function makeWrapper(initialEntries: string[] = ['/search']) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(MemoryRouter, { initialEntries }, children);
+}
+
+describe('useSearchFilters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('초기 상태: filterType null, filterMinRating undefined, filterSort popular', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.filterType).toBeNull();
+    expect(result.current.filterMinRating).toBeUndefined();
+    expect(result.current.filterSort).toBe('popular');
+    expect(result.current.noteSort).toBe('latest');
+    expect(result.current.filterOpen).toBe(false);
+  });
+
+  it('setFilterType 호출 시 filterType 업데이트', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setFilterType('녹차');
+    });
+
+    expect(result.current.filterType).toBe('녹차');
+  });
+
+  it('setFilterMinRating 호출 시 filterMinRating 업데이트', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setFilterMinRating(4);
+    });
+
+    expect(result.current.filterMinRating).toBe(4);
+  });
+
+  it('setFilterSort 호출 시 filterSort 업데이트', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setFilterSort('new');
+    });
+
+    expect(result.current.filterSort).toBe('new');
+  });
+
+  it('setNoteSort 호출 시 noteSort 업데이트', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setNoteSort('rating');
+    });
+
+    expect(result.current.noteSort).toBe('rating');
+  });
+
+  it('setFilterOpen 호출 시 filterOpen 업데이트', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setFilterOpen(true);
+    });
+
+    expect(result.current.filterOpen).toBe(true);
+  });
+
+  it('activeFilterCount: 아무 필터 없으면 0', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.activeFilterCount).toBe(0);
+  });
+
+  it('activeFilterCount: filterType 설정 시 1', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    act(() => {
+      result.current.setFilterType('홍차');
+    });
+
+    expect(result.current.activeFilterCount).toBe(1);
+  });
+
+  it('URL에 sort 파라미터 있으면 filterSort 초기화', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(['/search?sort=rating']),
+    });
+
+    expect(result.current.filterSort).toBe('rating');
+  });
+
+  it('URL에 type 파라미터 있으면 filterType 초기화', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(['/search?type=백차']),
+    });
+
+    expect(result.current.filterType).toBe('백차');
+  });
+
+  it('fetchWithFilters 호출 시 teasApi.getWithFilters 호출', async () => {
+    const { teasApi } = await import('../../lib/api');
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    const setTeas = vi.fn();
+    const setIsLoading = vi.fn();
+
+    await act(async () => {
+      await result.current.fetchWithFilters(
+        { q: '녹차', sort: 'popular' },
+        { setTeas, setIsLoading },
+      );
+    });
+
+    expect(teasApi.getWithFilters).toHaveBeenCalledWith(
+      expect.objectContaining({ q: '녹차' }),
+    );
+    expect(setTeas).toHaveBeenCalledWith([]);
+  });
+
+  it('fetchWithFilters - tags 있으면 teasApi.getByTags 호출', async () => {
+    const { teasApi } = await import('../../lib/api');
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    const setTeas = vi.fn();
+    const setIsLoading = vi.fn();
+
+    await act(async () => {
+      await result.current.fetchWithFilters(
+        { tags: ['꽃향', '부드러움'], sort: 'match' },
+        { setTeas, setIsLoading },
+      );
+    });
+
+    expect(teasApi.getByTags).toHaveBeenCalledWith(['꽃향', '부드러움'], 'match', 50);
+  });
+
+  it('hasTagParams: URL에 tags 없으면 false', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.hasTagParams).toBe(false);
+  });
+
+  it('hasFilterParams: URL 파라미터 없으면 false', () => {
+    const { result } = renderHook(() => useSearchFilters(), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.hasFilterParams).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useShare.test.ts
+++ b/src/hooks/__tests__/useShare.test.ts
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useShare } from '../useShare';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe('useShare', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('navigator.share 없을 때 clipboard.writeText 호출 → toast.success', async () => {
+    const { toast } = await import('sonner');
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useShare());
+    await result.current.share('테스트 차', 'https://chalog.app/tea/1');
+
+    expect(writeText).toHaveBeenCalledWith('https://chalog.app/tea/1');
+    expect(toast.success).toHaveBeenCalledWith('링크가 복사되었습니다');
+  });
+
+  it('clipboard 복사 실패 시 toast.error 호출', async () => {
+    const { toast } = await import('sonner');
+    Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+    const writeText = vi.fn().mockRejectedValue(new Error('clipboard error'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useShare());
+    await result.current.share('테스트 차', 'https://chalog.app/tea/1');
+
+    expect(toast.error).toHaveBeenCalledWith('링크 복사에 실패했습니다');
+  });
+
+  it('navigator.share 있을 때 navigator.share 호출', async () => {
+    const shareMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+
+    const { result } = renderHook(() => useShare());
+    await result.current.share('테스트 차', 'https://chalog.app/tea/1');
+
+    expect(shareMock).toHaveBeenCalledWith({
+      title: '테스트 차',
+      url: 'https://chalog.app/tea/1',
+    });
+  });
+
+  it('navigator.share AbortError 시 toast 미호출', async () => {
+    const { toast } = await import('sonner');
+    const abortError = new Error('abort');
+    abortError.name = 'AbortError';
+    const shareMock = vi.fn().mockRejectedValue(abortError);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+
+    const { result } = renderHook(() => useShare());
+    await result.current.share('테스트 차', 'https://chalog.app/tea/1');
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('navigator.share 오류(AbortError 제외) 시 clipboard 복사로 fallback', async () => {
+    const shareError = new Error('share failed');
+    shareError.name = 'NotAllowedError';
+    const shareMock = vi.fn().mockRejectedValue(shareError);
+    Object.defineProperty(navigator, 'share', { value: shareMock, configurable: true });
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useShare());
+    await result.current.share('테스트 차', 'https://chalog.app/tea/1');
+
+    expect(writeText).toHaveBeenCalledWith('https://chalog.app/tea/1');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #220
- 프론트엔드 훅 및 컴포넌트 누락 테스트 추가
- 백엔드 서비스 유닛 테스트 추가

### 추가된 프론트엔드 테스트 (Vitest)
- `src/hooks/__tests__/useNoteForm.test.ts` — 폼 상태, 유효성 검사, 저장 동작 (9 tests)
- `src/hooks/__tests__/usePostForm.test.ts` — 폼 상태, 유효성 검사, submit 동작 (8 tests)
- `src/hooks/__tests__/useSearchFilters.test.ts` — 필터 상태 변경, URL 파라미터 초기화, API 호출 (14 tests)
- `src/hooks/__tests__/useShare.test.ts` — Web Share API / clipboard fallback (5 tests)
- `src/components/__tests__/BottomNav.test.tsx` — 네비게이션 링크 렌더링 및 클릭 동작 (8 tests)

### 추가된 백엔드 테스트 (Jest)
- `backend/src/users/user-level.service.spec.ts` — 레벨 계산 및 배지 로직 (18 tests)
- `backend/src/teas/tea-recommendation.service.spec.ts` — 차 추천 서비스 유닛 테스트 (14 tests)
- `backend/src/teas/seller.service.spec.ts` — 찻집 CRUD 유닛 테스트 (15 tests)

## Test plan
- [x] `npx vitest run` — 프론트엔드 신규 테스트 45개 통과
- [x] `cd backend && npx jest` — 백엔드 신규 테스트 47개 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 판매자, 차 추천, 사용자 레벨 서비스에 대한 포괄적인 단위 테스트 추가
  * 하단 네비게이션, 노트 양식, 포스트 양식, 검색 필터, 공유 기능 컴포넌트 및 훅에 대한 테스트 스위트 추가
  * 전반적인 코드 품질 및 안정성 향상을 위한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->