### PR TITLE
feat: #207 #208 #210 홈 간소화, 프로필 컴포넌트 분리, 탐색/기록 모드 분리

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -13,21 +13,12 @@ export function HeroSection({ className }: HeroSectionProps) {
         '-mx-4 sm:-mx-6 -mt-6 sm:-mt-8',
         'rounded-b-2xl',
         'bg-linear-to-br from-primary/15 via-primary/10 to-primary/5',
-        'px-5 py-7 sm:px-6 sm:py-8',
+        'px-5 py-4 sm:px-6 sm:py-5',
         className,
       )}
     >
-      {/* 배경 장식 - 찻잎 실루엣 */}
       <div
-        className="absolute -right-8 -top-6 w-36 h-36 opacity-[0.08] pointer-events-none"
-        aria-hidden
-      >
-        <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full text-primary">
-          <path d="M12 2C6 8 6 16 12 22c6-6 6-14 0-20z" />
-        </svg>
-      </div>
-      <div
-        className="absolute -left-4 top-1/2 -translate-y-1/2 w-24 h-24 opacity-[0.05] pointer-events-none"
+        className="absolute -right-6 -top-4 w-28 h-28 opacity-[0.08] pointer-events-none"
         aria-hidden
       >
         <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full text-primary">
@@ -35,21 +26,16 @@ export function HeroSection({ className }: HeroSectionProps) {
         </svg>
       </div>
 
-      {/* 배경 로고 - 글자와 겹침 */}
-      <div
-        className="absolute right-4 top-1/2 -translate-y-1/2 w-48 h-48 sm:w-64 sm:h-64 opacity-[0.12] pointer-events-none"
-        aria-hidden
-      >
-        <img src="/logo.png" alt="" className="w-full h-full object-contain" />
-      </div>
-
-      <div className="relative flex flex-col gap-3.5 sm:gap-4">
-        <div className="space-y-1.5">
-          <p className="text-sm sm:text-base text-foreground/90 font-medium leading-snug">
-            차멍과 함께 차를 마시고, 소중한 순간을 기록하세요.
+      <div className="relative flex items-center gap-3">
+        <div className="w-8 h-8 shrink-0 opacity-80 pointer-events-none" aria-hidden>
+          <img src="/logo.png" alt="" className="w-full h-full object-contain" />
+        </div>
+        <div>
+          <p className="text-sm font-medium text-foreground/90 leading-snug">
+            차를 마시고, 소중한 순간을 기록하세요.
           </p>
-          <p className="text-sm text-muted-foreground leading-relaxed max-w-md">
-            나만의 차록을 쌓고, 함께하는 다우들의 차록으로 새로운 차를 발견하세요.
+          <p className="text-xs text-muted-foreground leading-relaxed mt-0.5">
+            다우들의 차록으로 새로운 차를 발견하세요.
           </p>
         </div>
       </div>

--- a/src/components/profile/ProfileHeader.tsx
+++ b/src/components/profile/ProfileHeader.tsx
@@ -1,0 +1,118 @@
+import { Camera, Globe, Instagram, Loader2, Pencil } from 'lucide-react';
+import { User } from '@/types';
+import { UserAvatar } from '@/components/ui/UserAvatar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+
+interface ProfileHeaderProps {
+  user: User;
+  isOwnProfile: boolean;
+  isFollowLoading: boolean;
+  onFollowToggle: () => void;
+  onEditImage: () => void;
+  onEditProfile: () => void;
+}
+
+export function ProfileHeader({
+  user,
+  isOwnProfile,
+  isFollowLoading,
+  onFollowToggle,
+  onEditImage,
+  onEditProfile,
+}: ProfileHeaderProps) {
+  return (
+    <Card className="p-4 sm:p-6">
+      <div className="flex flex-col items-center gap-3">
+        <div className="relative shrink-0">
+          <UserAvatar
+            name={user.name}
+            profileImageUrl={user.profileImageUrl}
+            size="md"
+          />
+          {isOwnProfile && (
+            <Button
+              onClick={onEditImage}
+              size="icon"
+              className="absolute bottom-0 right-0 rounded-full min-w-[44px] min-h-[44px] w-11 h-11 bg-primary hover:bg-primary/90 shadow-md border-2 border-background"
+              aria-label="프로필 사진 수정"
+            >
+              <Camera className="w-5 h-5" />
+            </Button>
+          )}
+        </div>
+
+        <div className="flex flex-col items-center text-center gap-2">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg sm:text-xl font-semibold text-primary">{user.name}</h2>
+            {isOwnProfile && (
+              <Button
+                onClick={onEditProfile}
+                size="icon"
+                variant="ghost"
+                className="w-7 h-7 rounded-full text-muted-foreground hover:text-foreground"
+                aria-label="프로필 편집"
+              >
+                <Pencil className="w-3.5 h-3.5" />
+              </Button>
+            )}
+          </div>
+
+          {user.bio && (
+            <p className="text-sm text-muted-foreground max-w-xs leading-snug">{user.bio}</p>
+          )}
+
+          {(user.instagramUrl || user.blogUrl) && (
+            <div className="flex items-center gap-2">
+              {user.instagramUrl && (
+                <a
+                  href={user.instagramUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label="인스타그램"
+                >
+                  <Instagram className="w-3.5 h-3.5" />
+                </a>
+              )}
+              {user.blogUrl && (
+                <a
+                  href={user.blogUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label="블로그"
+                >
+                  <Globe className="w-3.5 h-3.5" />
+                </a>
+              )}
+            </div>
+          )}
+
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <span>구독자 {(user.followerCount ?? 0).toLocaleString('ko-KR')}</span>
+            <span>구독 {(user.followingCount ?? 0).toLocaleString('ko-KR')}</span>
+          </div>
+
+          {!isOwnProfile && (
+            <Button
+              onClick={onFollowToggle}
+              disabled={isFollowLoading}
+              variant={user.isFollowing ? 'outline' : 'default'}
+              size="sm"
+              className="mt-1 min-w-[88px]"
+            >
+              {isFollowLoading ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : user.isFollowing ? (
+                '구독 중'
+              ) : (
+                '구독'
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/profile/ProfileStats.tsx
+++ b/src/components/profile/ProfileStats.tsx
@@ -1,0 +1,63 @@
+import { FileText, Heart, Star } from 'lucide-react';
+import { UserLevel } from '@/types';
+import { StatCard } from '@/components/ui/StatCard';
+import { cn } from '@/components/ui/utils';
+
+interface ProfileStatsData {
+  averageRating: number;
+  totalLikes: number;
+  noteCount: number;
+}
+
+interface ProfileStatsProps {
+  stats: ProfileStatsData;
+  userLevel: UserLevel | null;
+}
+
+export function ProfileStats({ stats, userLevel }: ProfileStatsProps) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-3 gap-2 sm:gap-3">
+        <StatCard icon={Star} value={stats.averageRating} label="평균 평점" />
+        <StatCard icon={Heart} value={stats.totalLikes.toLocaleString('ko-KR')} label="총 좋아요" />
+        <StatCard icon={FileText} value={stats.noteCount} label="작성한 차록" />
+      </div>
+
+      {userLevel && (
+        <div className="flex flex-col gap-3">
+          <div className="grid grid-cols-3 gap-2">
+            {[
+              { label: '차록', info: userLevel.noteLevel },
+              { label: '게시글', info: userLevel.postLevel },
+              { label: '찻장', info: userLevel.cellarLevel },
+            ].map(({ label, info }) => (
+              <div
+                key={label}
+                className={cn(
+                  'flex flex-col items-center gap-0.5 p-2 rounded-lg bg-muted/40 text-center',
+                )}
+              >
+                <span className="text-xs text-muted-foreground">{label}</span>
+                <span className="text-sm font-semibold text-primary">{info.name}</span>
+                <span className="text-xs text-muted-foreground">Lv.{info.level}</span>
+              </div>
+            ))}
+          </div>
+
+          {userLevel.badges.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {userLevel.badges.map((b) => (
+                <span
+                  key={b.id}
+                  className="px-2 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-medium"
+                >
+                  {b.name}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/UserNoteList.tsx
+++ b/src/components/profile/UserNoteList.tsx
@@ -1,0 +1,110 @@
+import { useNavigate } from 'react-router-dom';
+import { BarChart2, Bookmark } from 'lucide-react';
+import { Note } from '@/types';
+import { NoteCard } from '@/components/NoteCard';
+import { EmptyState } from '@/components/EmptyState';
+import { InfiniteScrollSentinel } from '@/components/InfiniteScrollSentinel';
+import { Section } from '@/components/ui/Section';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+type SortType = 'latest' | 'rating';
+
+interface UserNoteListProps {
+  notes: Note[];
+  noteTotal: number;
+  sort: SortType;
+  onSortChange: (sort: SortType) => void;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+  isOwnProfile: boolean;
+}
+
+export function UserNoteList({
+  notes,
+  noteTotal,
+  sort,
+  onSortChange,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+  isOwnProfile,
+}: UserNoteListProps) {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      {notes.length > 0 && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">총 {noteTotal}개</span>
+          <Select value={sort} onValueChange={(v) => onSortChange(v as SortType)}>
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="latest">최신순</SelectItem>
+              <SelectItem value="rating">별점순</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      <Section
+        title="차록"
+        spacing="lg"
+        headerAction={
+          isOwnProfile ? (
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate('/report')}
+                className="text-muted-foreground hover:text-foreground gap-1.5"
+              >
+                <BarChart2 className="w-4 h-4" />
+                레포트
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate('/saved')}
+                className="text-muted-foreground hover:text-foreground gap-1.5"
+              >
+                <Bookmark className="w-4 h-4" />
+                저장함
+              </Button>
+            </div>
+          ) : undefined
+        }
+      >
+        {notes.length > 0 ? (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {notes.map((note) => (
+                <NoteCard key={note.id} note={note} showTeaName />
+              ))}
+            </div>
+            <InfiniteScrollSentinel
+              onLoadMore={onLoadMore}
+              loading={isLoadingMore}
+              hasMore={hasMore}
+            />
+          </>
+        ) : (
+          <EmptyState
+            type="notes"
+            message="아직 작성한 차록이 없어요."
+            action={{ label: '첫 차록 쓰기', onClick: () => navigate('/note/new') }}
+          />
+        )}
+      </Section>
+    </>
+  );
+}

--- a/src/components/profile/__tests__/ProfileHeader.test.tsx
+++ b/src/components/profile/__tests__/ProfileHeader.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { ProfileHeader } from '../ProfileHeader';
+import { User } from '@/types';
+
+vi.mock('@/components/ui/UserAvatar', () => ({
+  UserAvatar: ({ name }: { name: string; profileImageUrl?: string | null }) => (
+    <div data-testid="user-avatar">{name.charAt(0).toUpperCase()}</div>
+  ),
+}));
+
+const mockUser: User = {
+  id: 1,
+  name: '김차인',
+  email: 'tea@example.com',
+  bio: '차를 좋아합니다.',
+  followerCount: 42,
+  followingCount: 10,
+  isFollowing: false,
+};
+
+function renderProfileHeader(overrides: Partial<Parameters<typeof ProfileHeader>[0]> = {}) {
+  const props = {
+    user: mockUser,
+    isOwnProfile: false,
+    isFollowLoading: false,
+    onFollowToggle: vi.fn(),
+    onEditImage: vi.fn(),
+    onEditProfile: vi.fn(),
+    ...overrides,
+  };
+  return render(
+    <MemoryRouter>
+      <ProfileHeader {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ProfileHeader', () => {
+  it('사용자 이름을 표시한다', () => {
+    renderProfileHeader();
+    expect(screen.getByRole('heading', { name: '김차인' })).toBeInTheDocument();
+  });
+
+  it('bio를 표시한다', () => {
+    renderProfileHeader();
+    expect(screen.getByText('차를 좋아합니다.')).toBeInTheDocument();
+  });
+
+  it('구독자/구독 수를 표시한다', () => {
+    renderProfileHeader();
+    expect(screen.getByText('구독자 42')).toBeInTheDocument();
+    expect(screen.getByText('구독 10')).toBeInTheDocument();
+  });
+
+  it('타인 프로필일 때 구독 버튼을 표시한다', () => {
+    renderProfileHeader({ isOwnProfile: false });
+    expect(screen.getByRole('button', { name: /구독/ })).toBeInTheDocument();
+  });
+
+  it('내 프로필일 때 구독 버튼을 표시하지 않는다', () => {
+    renderProfileHeader({ isOwnProfile: true });
+    expect(screen.queryByRole('button', { name: /^구독$/ })).not.toBeInTheDocument();
+  });
+
+  it('내 프로필일 때 프로필 사진 수정 버튼을 표시한다', () => {
+    renderProfileHeader({ isOwnProfile: true });
+    expect(screen.getByLabelText('프로필 사진 수정')).toBeInTheDocument();
+  });
+
+  it('타인 프로필일 때 프로필 사진 수정 버튼을 표시하지 않는다', () => {
+    renderProfileHeader({ isOwnProfile: false });
+    expect(screen.queryByLabelText('프로필 사진 수정')).not.toBeInTheDocument();
+  });
+
+  it('구독 버튼 클릭 시 onFollowToggle을 호출한다', async () => {
+    const onFollowToggle = vi.fn();
+    renderProfileHeader({ isOwnProfile: false, onFollowToggle });
+    await userEvent.click(screen.getByRole('button', { name: /구독/ }));
+    expect(onFollowToggle).toHaveBeenCalledOnce();
+  });
+
+  it('이미 구독 중이면 "구독 중" 텍스트를 표시한다', () => {
+    renderProfileHeader({ user: { ...mockUser, isFollowing: true } });
+    expect(screen.getByRole('button', { name: '구독 중' })).toBeInTheDocument();
+  });
+
+  it('인스타그램 링크를 표시한다', () => {
+    renderProfileHeader({ user: { ...mockUser, instagramUrl: 'https://instagram.com/test' } });
+    expect(screen.getByLabelText('인스타그램')).toHaveAttribute('href', 'https://instagram.com/test');
+  });
+
+  it('블로그 링크를 표시한다', () => {
+    renderProfileHeader({ user: { ...mockUser, blogUrl: 'https://blog.example.com' } });
+    expect(screen.getByLabelText('블로그')).toHaveAttribute('href', 'https://blog.example.com');
+  });
+});

--- a/src/contexts/AppModeContext.tsx
+++ b/src/contexts/AppModeContext.tsx
@@ -6,9 +6,12 @@ type SessionState = {
   sessionId?: number;
 };
 
+export type AppMode = 'explore' | 'record';
+
 type AppModeState = {
   sessionMode: SessionState;
   blindMode: SessionState;
+  appMode: AppMode;
 };
 
 type AppModeContextType = AppModeState & {
@@ -18,6 +21,7 @@ type AppModeContextType = AppModeState & {
   setBlindActive: (sessionId: number) => void;
   clearSession: () => void;
   clearBlind: () => void;
+  setAppMode: (mode: AppMode) => void;
 };
 
 const STORAGE_KEY = 'chalog-app-mode';
@@ -25,6 +29,7 @@ const STORAGE_KEY = 'chalog-app-mode';
 const defaultState: AppModeState = {
   sessionMode: { active: false },
   blindMode: { active: false },
+  appMode: 'explore',
 };
 
 const AppModeContext = createContext<AppModeContextType | null>(null);
@@ -34,7 +39,9 @@ export function AppModeProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<AppModeState>(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
-      return stored ? (JSON.parse(stored) as AppModeState) : defaultState;
+      if (!stored) return defaultState;
+      const parsed = JSON.parse(stored) as Partial<AppModeState>;
+      return { ...defaultState, ...parsed };
     } catch {
       return defaultState;
     }
@@ -76,6 +83,10 @@ export function AppModeProvider({ children }: { children: React.ReactNode }) {
     setState((prev) => ({ ...prev, blindMode: { active: false } }));
   }, []);
 
+  const setAppMode = useCallback((mode: AppMode) => {
+    setState((prev) => ({ ...prev, appMode: mode }));
+  }, []);
+
   return (
     <AppModeContext.Provider
       value={{
@@ -86,6 +97,7 @@ export function AppModeProvider({ children }: { children: React.ReactNode }) {
         setBlindActive,
         clearSession,
         clearBlind,
+        setAppMode,
       }}
     >
       {children}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { Header } from '../components/Header';
 import { HeroSection } from '../components/HeroSection';
 import { BottomNav } from '../components/BottomNav';
-import { Section } from '../components/ui/Section';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/tabs';
 import { ForYouFeed } from '../components/feeds/ForYouFeed';
 import { FollowingFeed } from '../components/feeds/FollowingFeed';
@@ -18,6 +17,12 @@ import { toast } from 'sonner';
 import { useAuth } from '../contexts/AuthContext';
 
 type FeedTab = 'forYou' | 'following' | 'tags';
+
+const TAB_LABELS: Record<FeedTab, { label: string; desc: string }> = {
+  forYou: { label: '맞춤', desc: '나를 위한 차록' },
+  following: { label: '구독', desc: '내가 구독한 다우' },
+  tags: { label: '향미', desc: '관심 향미 태그 차록' },
+};
 
 export function Home() {
   const { user: currentUser, isLoading: authLoading } = useAuth();
@@ -129,13 +134,11 @@ export function Home() {
     return (
       <div className="min-h-screen pb-20">
         <Header showProfile showLogo />
-        <div className="px-4 py-6 pb-20 sm:px-6 sm:py-8 space-y-6 sm:space-y-8">
+        <div className="px-4 py-6 pb-20 sm:px-6 sm:py-8 space-y-4 sm:space-y-6">
           <HeroSection />
-          <Section title="📄 차록 흐름" description="다양한 차록을 둘러보세요." spacing="lg">
-            <div className="space-y-3">
-              {[1, 2, 3, 4].map((i) => <NoteCardSkeleton key={i} />)}
-            </div>
-          </Section>
+          <div className="space-y-3">
+            {[1, 2, 3, 4].map((i) => <NoteCardSkeleton key={i} />)}
+          </div>
           <footer className="mt-12 pt-8 pb-6 border-t border-border/40">
             <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
               <span>차멍 v0.1</span><span className="text-border">·</span>
@@ -153,20 +156,26 @@ export function Home() {
   return (
     <div className="min-h-screen pb-20">
       <Header showProfile showLogo />
-      <div className="px-4 py-6 pb-20 sm:px-6 sm:py-8 space-y-6 sm:space-y-8">
+      <div className="px-4 py-6 pb-20 sm:px-6 sm:py-8 space-y-4 sm:space-y-6">
         <HeroSection />
         <HomeTrendingSection trendingTeas={trendingTeas} trendingCreators={trendingCreators} />
-        <Section title="📄 차록 흐름" description="다양한 차록을 둘러보세요." spacing="lg">
+        <section aria-label="차록 흐름">
+          <div className="flex items-baseline justify-between mb-3">
+            <h2 className="text-sm font-semibold text-foreground">차록 흐름</h2>
+            <p className="text-xs text-muted-foreground">{TAB_LABELS[activeTab].desc}</p>
+          </div>
           <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as FeedTab)}>
-            <TabsList className="w-full">
-              <TabsTrigger value="forYou" className="flex-1">맞춤차</TabsTrigger>
-              <TabsTrigger value="following" className="flex-1">구독</TabsTrigger>
-              <TabsTrigger value="tags" className="flex-1">향미</TabsTrigger>
+            <TabsList className="w-full mb-4">
+              {(Object.keys(TAB_LABELS) as FeedTab[]).map((tab) => (
+                <TabsTrigger key={tab} value={tab} className="flex-1 text-sm font-medium">
+                  {TAB_LABELS[tab].label}
+                </TabsTrigger>
+              ))}
             </TabsList>
-            <TabsContent value="forYou" className="mt-4">
+            <TabsContent value="forYou">
               <ForYouFeed notes={publicNotes} />
             </TabsContent>
-            <TabsContent value="following" className="mt-4">
+            <TabsContent value="following">
               <FollowingFeed
                 notes={followingNotes}
                 isLoading={isFollowingLoading}
@@ -174,7 +183,7 @@ export function Home() {
                 authLoading={authLoading}
               />
             </TabsContent>
-            <TabsContent value="tags" className="mt-4">
+            <TabsContent value="tags">
               <TagsFeed
                 notes={tagNotes}
                 followedTags={followedTags}
@@ -184,7 +193,7 @@ export function Home() {
               />
             </TabsContent>
           </Tabs>
-        </Section>
+        </section>
         <HomeFooter recentContributors={recentContributors} />
       </div>
       <BottomNav />

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,26 +1,14 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Header } from '../components/Header';
-import { NoteCard } from '../components/NoteCard';
-
 import { EmptyState } from '../components/EmptyState';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '../components/ui/select';
 import { BottomNav } from '../components/BottomNav';
 import { usersApi, notesApi, followsApi } from '../lib/api';
 import { User, Note, UserOnboardingPreference, UserLevel } from '../types';
 import { toast } from 'sonner';
-import { Loader2, Star, Heart, FileText, Camera, Instagram, Globe, Pencil, Bookmark, BarChart2 } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import { logger } from '../lib/logger';
-import { UserAvatar } from '../components/ui/UserAvatar';
-import { StatCard } from '../components/ui/StatCard';
 import { Card } from '../components/ui/card';
-import { Section } from '../components/ui/Section';
 import { ProfileImageEditModal } from '../components/ProfileImageEditModal';
 import { ProfileEditModal } from '../components/ProfileEditModal';
 import { OnboardingPreferenceEditModal } from '../components/OnboardingPreferenceEditModal';
@@ -29,7 +17,9 @@ import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import { TEA_TYPES, TEA_TYPE_COLORS } from '../constants';
 import { cn } from '../components/ui/utils';
-import { InfiniteScrollSentinel } from '../components/InfiniteScrollSentinel';
+import { ProfileHeader } from '../components/profile/ProfileHeader';
+import { ProfileStats } from '../components/profile/ProfileStats';
+import { UserNoteList } from '../components/profile/UserNoteList';
 
 type SortType = 'latest' | 'rating';
 
@@ -53,10 +43,8 @@ export function UserProfile() {
   const [onboardingPreference, setOnboardingPreference] = useState<UserOnboardingPreference | null>(null);
   const [userLevel, setUserLevel] = useState<UserLevel | null>(null);
 
-  const isOwnProfile = !authLoading && currentUser && userId === currentUser.id;
-
+  const isOwnProfile = !authLoading && !!currentUser && userId === currentUser.id;
   const [isPrivateProfile, setIsPrivateProfile] = useState(false);
-
   const initialLoadDone = useRef(false);
 
   useEffect(() => {
@@ -105,7 +93,6 @@ export function UserProfile() {
       setUser(userData as User);
       setOnboardingPreference(pref);
       initialLoadDone.current = true;
-
     } catch (error: unknown) {
       logger.error('Failed to fetch user profile:', error);
       const statusCode = (error as { statusCode?: number })?.statusCode;
@@ -126,7 +113,6 @@ export function UserProfile() {
     fetchData();
   }, [authLoading, fetchData]);
 
-  // 정렬 변경 시 노트만 다시 가져오기 (초기 로드 이후)
   useEffect(() => {
     if (!initialLoadDone.current) return;
     setNotePage(1);
@@ -157,7 +143,6 @@ export function UserProfile() {
       navigate('/login');
       return;
     }
-
     if (!user) return;
 
     setIsFollowLoading(true);
@@ -165,31 +150,17 @@ export function UserProfile() {
     const delta = prevIsFollowing ? -1 : 1;
 
     setUser((prev) =>
-      prev
-        ? {
-            ...prev,
-            isFollowing: !prevIsFollowing,
-            followerCount: (prev.followerCount ?? 0) + delta,
-          }
-        : prev,
+      prev ? { ...prev, isFollowing: !prevIsFollowing, followerCount: (prev.followerCount ?? 0) + delta } : prev,
     );
 
     try {
       const result = await followsApi.toggle(userId) as { isFollowing: boolean };
-      // optimistic update already adjusted followerCount; only sync isFollowing from server
-      setUser((prev) =>
-        prev
-          ? { ...prev, isFollowing: result.isFollowing }
-          : prev,
-      );
+      setUser((prev) => prev ? { ...prev, isFollowing: result.isFollowing } : prev);
     } catch (error) {
+      logger.error('Follow toggle failed:', error);
       setUser((prev) =>
         prev
-          ? {
-              ...prev,
-              isFollowing: prevIsFollowing,
-              followerCount: (prev.followerCount ?? 0) - delta,
-            }
+          ? { ...prev, isFollowing: prevIsFollowing, followerCount: (prev.followerCount ?? 0) - delta }
           : prev,
       );
       toast.error('구독 처리 중 오류가 발생했습니다.');
@@ -199,39 +170,19 @@ export function UserProfile() {
   };
 
   const stats = useMemo(() => {
-    if (notes.length === 0) {
-      return {
-        averageRating: 0,
-        totalLikes: 0,
-        noteCount: 0,
-      };
-    }
-
+    if (notes.length === 0) return { averageRating: 0, totalLikes: 0, noteCount: 0 };
     const averageRating = notes.reduce((sum, note) => sum + (note.overallRating || 0), 0) / notes.length;
     const totalLikes = notes.reduce((sum, note) => sum + (note.likeCount || 0), 0);
-
     const safeAverageRating = isNaN(averageRating) ? 0 : Number(averageRating.toFixed(1));
-
-    return {
-      averageRating: safeAverageRating,
-      totalLikes,
-      noteCount: noteTotal || notes.length,
-    };
+    return { averageRating: safeAverageRating, totalLikes, noteCount: noteTotal || notes.length };
   }, [notes, noteTotal]);
 
-  // 서버에서 정렬된 상태로 반환되므로 클라이언트 정렬 불필요
-  const sortedNotes = notes;
-
   const handleProfileImageUpdate = (imageUrl: string) => {
-    if (user) {
-      setUser({ ...user, profileImageUrl: imageUrl || null });
-    }
+    if (user) setUser({ ...user, profileImageUrl: imageUrl || null });
   };
 
   const handleProfileInfoUpdate = (updatedFields: Partial<User>) => {
-    if (user) {
-      setUser({ ...user, ...updatedFields });
-    }
+    if (user) setUser({ ...user, ...updatedFields });
   };
 
   if (isLoading) {
@@ -244,8 +195,7 @@ export function UserProfile() {
           title={isOwnProfile ? '내 차록' : '사용자 프로필'}
         />
         <div className="p-6 space-y-6">
-          {/* 프로필 카드 스켈레톤 */}
-          <Card className="p-4 sm:p-6 md:p-8">
+          <Card className="p-4 sm:p-6">
             <div className="flex flex-col items-center gap-3 mb-6">
               <div className="w-20 h-20 rounded-full bg-muted animate-pulse" />
               <div className="flex flex-col items-center gap-2">
@@ -254,7 +204,6 @@ export function UserProfile() {
               </div>
             </div>
           </Card>
-          {/* 통계 스켈레톤 */}
           <div className="grid grid-cols-3 gap-2 sm:gap-3">
             {[1, 2, 3].map((i) => (
               <Card key={i} className="p-3 flex flex-col items-center gap-1">
@@ -263,7 +212,6 @@ export function UserProfile() {
               </Card>
             ))}
           </div>
-          {/* 노트 리스트 스켈레톤 */}
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
               <div key={i} className="h-24 rounded-lg bg-muted animate-pulse" />
@@ -317,164 +265,35 @@ export function UserProfile() {
       />
 
       <div className="p-6 space-y-6">
-        {/* 프로필 헤더 섹션 */}
-        <Card className="p-4 sm:p-6 md:p-8">
-          <div className="flex flex-col items-center gap-3 mb-6">
-            <div className="relative shrink-0">
-              <UserAvatar
-                name={user.name}
-                profileImageUrl={user.profileImageUrl}
-                size="md"
-              />
-              {isOwnProfile && (
-                <Button
-                  onClick={() => setIsEditModalOpen(true)}
-                  size="icon"
-                  className="absolute bottom-0 right-0 rounded-full min-w-[44px] min-h-[44px] w-11 h-11 bg-primary hover:bg-primary/90 shadow-md border-2 border-background"
-                  aria-label="프로필 사진 수정"
-                >
-                  <Camera className="w-5 h-5" />
-                </Button>
-              )}
-            </div>
-            <div className="flex flex-col items-center text-center gap-2">
-              <div className="flex items-center gap-2">
-                <h2 className="text-lg sm:text-xl font-semibold text-primary">{user.name}</h2>
-                {isOwnProfile && (
-                  <Button
-                    onClick={() => setIsProfileEditModalOpen(true)}
-                    size="icon"
-                    variant="ghost"
-                    className="w-7 h-7 rounded-full text-muted-foreground hover:text-foreground"
-                    aria-label="프로필 편집"
-                  >
-                    <Pencil className="w-3.5 h-3.5" />
-                  </Button>
-                )}
-              </div>
-              {user.bio && (
-                <p className="text-sm text-muted-foreground max-w-[240px] leading-snug">{user.bio}</p>
-              )}
-              {(user.instagramUrl || user.blogUrl) && (
-                <div className="flex items-center gap-2">
-                  {user.instagramUrl && (
-                    <a
-                      href={user.instagramUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      aria-label="인스타그램"
-                    >
-                      <Instagram className="w-3.5 h-3.5" />
-                    </a>
-                  )}
-                  {user.blogUrl && (
-                    <a
-                      href={user.blogUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      aria-label="블로그"
-                    >
-                      <Globe className="w-3.5 h-3.5" />
-                    </a>
-                  )}
-                </div>
-              )}
-              <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                <span>구독자 {(user.followerCount ?? 0).toLocaleString('ko-KR')}</span>
-                <span>구독 {(user.followingCount ?? 0).toLocaleString('ko-KR')}</span>
-              </div>
-              {!isOwnProfile && !authLoading && (
-                <Button
-                  onClick={handleFollowToggle}
-                  disabled={isFollowLoading}
-                  variant={user.isFollowing ? 'outline' : 'default'}
-                  size="sm"
-                  className="mt-1 min-w-[88px]"
-                >
-                  {isFollowLoading ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                  ) : user.isFollowing ? (
-                    '구독 중'
-                  ) : (
-                    '구독'
-                  )}
-                </Button>
-              )}
-            </div>
-          </div>
-        </Card>
+        <ProfileHeader
+          user={user}
+          isOwnProfile={isOwnProfile}
+          isFollowLoading={isFollowLoading}
+          onFollowToggle={handleFollowToggle}
+          onEditImage={() => setIsEditModalOpen(true)}
+          onEditProfile={() => setIsProfileEditModalOpen(true)}
+        />
 
-        {/* 프로필 사진 수정 모달 */}
-        {isOwnProfile && user && (
-          <ProfileImageEditModal
-            open={isEditModalOpen}
-            onOpenChange={setIsEditModalOpen}
-            currentImageUrl={user.profileImageUrl}
-            onSuccess={handleProfileImageUpdate}
-            userId={user.id}
-          />
+        {isOwnProfile && (
+          <>
+            <ProfileImageEditModal
+              open={isEditModalOpen}
+              onOpenChange={setIsEditModalOpen}
+              currentImageUrl={user.profileImageUrl}
+              onSuccess={handleProfileImageUpdate}
+              userId={user.id}
+            />
+            <ProfileEditModal
+              open={isProfileEditModalOpen}
+              onOpenChange={setIsProfileEditModalOpen}
+              user={user}
+              onSuccess={handleProfileInfoUpdate}
+            />
+          </>
         )}
 
-        {/* 프로필 정보 편집 모달 */}
-        {isOwnProfile && user && (
-          <ProfileEditModal
-            open={isProfileEditModalOpen}
-            onOpenChange={setIsProfileEditModalOpen}
-            user={user}
-            onSuccess={handleProfileInfoUpdate}
-          />
-        )}
+        <ProfileStats stats={stats} userLevel={userLevel} />
 
-        {/* 통계 카드 섹션 */}
-        <div className="grid grid-cols-3 gap-2 sm:gap-3">
-          <StatCard
-            icon={Star}
-            value={stats.averageRating}
-            label="평균 평점"
-          />
-          <StatCard
-            icon={Heart}
-            value={stats.totalLikes.toLocaleString('ko-KR')}
-            label="총 좋아요"
-          />
-          <StatCard
-            icon={FileText}
-            value={stats.noteCount}
-            label="작성한 차록"
-          />
-        </div>
-
-        {/* 레벨/뱃지 섹션 */}
-        {userLevel && (
-          <div className="flex flex-col gap-3">
-            <div className="grid grid-cols-3 gap-2">
-              {[
-                { label: '차록', info: userLevel.noteLevel },
-                { label: '게시글', info: userLevel.postLevel },
-                { label: '찻장', info: userLevel.cellarLevel },
-              ].map(({ label, info }) => (
-                <div key={label} className="flex flex-col items-center gap-0.5 p-2 rounded-lg bg-muted/40 text-center">
-                  <span className="text-xs text-muted-foreground">{label}</span>
-                  <span className="text-sm font-semibold text-primary">{info.name}</span>
-                  <span className="text-xs text-muted-foreground">Lv.{info.level}</span>
-                </div>
-              ))}
-            </div>
-            {userLevel.badges.length > 0 && (
-              <div className="flex flex-wrap gap-1.5">
-                {userLevel.badges.map((b) => (
-                  <span key={b.id} className="px-2 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-medium">
-                    {b.name}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* 취향 정보 섹션 - 내 프로필에서만 표시 */}
         {isOwnProfile && onboardingPreference && (
           <Card className="p-4 sm:p-6 space-y-4">
             <div className="flex items-center justify-between mb-2">
@@ -535,8 +354,7 @@ export function UserProfile() {
           </Card>
         )}
 
-        {/* 취향 수정 모달 */}
-        {isOwnProfile && user && (
+        {isOwnProfile && (
           <OnboardingPreferenceEditModal
             open={isOnboardingEditModalOpen}
             onOpenChange={setIsOnboardingEditModalOpen}
@@ -546,74 +364,16 @@ export function UserProfile() {
           />
         )}
 
-        {/* 정렬 드롭다운 */}
-        {notes.length > 0 && (
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-muted-foreground">
-              총 {noteTotal}개
-            </span>
-            <Select value={sort} onValueChange={(v) => setSort(v as SortType)}>
-              <SelectTrigger className="w-32">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="latest">최신순</SelectItem>
-                <SelectItem value="rating">별점순</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-
-        {/* 노트 목록 섹션 */}
-        <Section
-          title="차록"
-          spacing="lg"
-          headerAction={
-            isOwnProfile ? (
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => navigate('/report')}
-                  className="text-muted-foreground hover:text-foreground gap-1.5"
-                >
-                  <BarChart2 className="w-4 h-4" />
-                  레포트
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => navigate('/saved')}
-                  className="text-muted-foreground hover:text-foreground gap-1.5"
-                >
-                  <Bookmark className="w-4 h-4" />
-                  저장함
-                </Button>
-              </div>
-            ) : undefined
-          }
-        >
-          {sortedNotes.length > 0 ? (
-            <>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                {sortedNotes.map(note => (
-                  <NoteCard key={note.id} note={note} showTeaName />
-                ))}
-              </div>
-              <InfiniteScrollSentinel
-                onLoadMore={loadMore}
-                loading={isLoadingMore}
-                hasMore={hasMore}
-              />
-            </>
-          ) : (
-            <EmptyState
-              type="notes"
-              message="아직 작성한 차록이 없어요."
-              action={{ label: '첫 차록 쓰기', onClick: () => navigate('/note/new') }}
-            />
-          )}
-        </Section>
+        <UserNoteList
+          notes={notes}
+          noteTotal={noteTotal}
+          sort={sort}
+          onSortChange={setSort}
+          hasMore={hasMore}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={loadMore}
+          isOwnProfile={isOwnProfile}
+        />
       </div>
 
       <BottomNav />

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -72,6 +72,9 @@ vi.mock('../../lib/api', () => ({
   usersApi: {
     getTrending: vi.fn(() => Promise.resolve([])),
   },
+  authApi: {
+    getMe: vi.fn(() => Promise.resolve({ user: null })),
+  },
   tagsApi: {
     getFollowedTags: vi.fn(() => Promise.resolve([])),
   },

--- a/src/pages/__tests__/UserProfile.test.tsx
+++ b/src/pages/__tests__/UserProfile.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../lib/api', async () => {
   return {
     ...actual,
     usersApi: {
+      getLevel: vi.fn(() => Promise.resolve(null)),
       getById: vi.fn(),
       getOnboardingPreference: vi.fn(),
     },


### PR DESCRIPTION
## Summary
- Closes #207
- Closes #208
- Closes #210
- Closes #101

### #207 홈 페이지 간소화
- HeroSection 컴팩트 리디자인 (세로 패딩 축소, 텍스트 2줄로 단축, 로고 인라인 배치)
- 차록 흐름 탭 레이블 개선: 맞춤차→맞춤, 구독, 향미
- 활성 탭에 따라 설명 텍스트 동적 표시
- `Section` 래퍼 제거로 불필요한 중첩 감소

### #208 UserProfile 컴포넌트 분리
- `src/components/profile/ProfileHeader.tsx`: 아바타, 이름, bio, 링크, 팔로우 버튼
- `src/components/profile/ProfileStats.tsx`: 통계 카드(평점/좋아요/차록수), 레벨/뱃지
- `src/components/profile/UserNoteList.tsx`: 정렬 드롭다운, 노트 카드, 무한스크롤
- UserProfile 페이지는 오케스트레이터 역할만 유지

### #210 탐색/기록 모드 분리
- `AppModeContext`에 `appMode: 'explore' | 'record'` 상태 추가
- `setAppMode(mode)` 액션 추가
- `AppMode` 타입 export
- localStorage 직렬화 시 기존 상태와 병합(하위 호환 유지)

### #101 스타일 개선
- 카드 패딩 일관성 개선 (`p-4 sm:p-6`)
- 간격 축소 (`space-y-6 sm:space-y-8` → `space-y-4 sm:space-y-6`)

## Test plan
- [x] `npm run build` 통과
- [x] `ProfileHeader` 신규 테스트 11개 통과
- [x] `UserProfile` 테스트 16개 통과 (getLevel mock 추가)
- [x] `Home` 테스트 mock에 `authApi` 추가 (기존 실패 테스트는 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)