### PR TITLE
feat: #204 #221 검색어 없이 필터/정렬, 스크롤 위치 복원

### DIFF
--- a/src/hooks/__tests__/useScrollRestoration.test.ts
+++ b/src/hooks/__tests__/useScrollRestoration.test.ts
@@ -1,0 +1,95 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRef } from 'react';
+import { useScrollRestoration } from '../useScrollRestoration';
+
+const mockPathname = { current: '/' };
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: mockPathname.current }),
+}));
+
+describe('useScrollRestoration', () => {
+  let originalScrollTo: typeof window.scrollTo;
+  let scrollYValue = 0;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    originalScrollTo = window.scrollTo;
+    window.scrollTo = vi.fn();
+    scrollYValue = 0;
+    Object.defineProperty(window, 'scrollY', {
+      get: () => scrollYValue,
+      configurable: true,
+    });
+    mockPathname.current = '/';
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    window.scrollTo = originalScrollTo;
+    vi.unstubAllGlobals();
+  });
+
+  it('저장된 스크롤 위치가 없으면 window.scrollTo를 호출하지 않는다', () => {
+    renderHook(() => useScrollRestoration());
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('sessionStorage에 저장된 스크롤 위치를 복원한다', () => {
+    sessionStorage.setItem('scroll_pos_/', '350');
+    renderHook(() => useScrollRestoration());
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 350);
+  });
+
+  it('언마운트 시 현재 scrollY를 sessionStorage에 저장한다', () => {
+    scrollYValue = 200;
+    const { unmount } = renderHook(() => useScrollRestoration());
+    unmount();
+    expect(sessionStorage.getItem('scroll_pos_/')).toBe('200');
+  });
+
+  it('pathname 변경 후 언마운트 시 새 경로의 스크롤 위치를 저장한다', () => {
+    scrollYValue = 500;
+    mockPathname.current = '/search';
+
+    const { unmount } = renderHook(() => useScrollRestoration());
+    unmount();
+
+    expect(sessionStorage.getItem('scroll_pos_/search')).toBe('500');
+  });
+
+  it('scrollContainerRef가 있으면 scrollTop을 기준으로 복원한다', () => {
+    const ref = createRef<HTMLDivElement>();
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'scrollTop', { value: 0, writable: true, configurable: true });
+    (ref as React.MutableRefObject<HTMLDivElement>).current = div;
+
+    sessionStorage.setItem('scroll_pos_/', '120');
+
+    renderHook(() => useScrollRestoration(ref));
+
+    expect(div.scrollTop).toBe(120);
+  });
+
+  it('scrollContainerRef가 있을 때 언마운트 시 scrollTop을 저장한다', () => {
+    const ref = createRef<HTMLDivElement>();
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'scrollTop', { value: 300, writable: true, configurable: true });
+    (ref as React.MutableRefObject<HTMLDivElement>).current = div;
+
+    const { unmount } = renderHook(() => useScrollRestoration(ref));
+    unmount();
+
+    expect(sessionStorage.getItem('scroll_pos_/')).toBe('300');
+  });
+
+  it('유효하지 않은 저장값은 복원하지 않는다', () => {
+    sessionStorage.setItem('scroll_pos_/', 'invalid');
+    renderHook(() => useScrollRestoration());
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const STORAGE_PREFIX = 'scroll_pos_';
+
+function getKey(pathname: string): string {
+  return `${STORAGE_PREFIX}${pathname}`;
+}
+
+/**
+ * 라우트 이탈 시 스크롤 위치를 sessionStorage에 저장하고,
+ * 해당 라우트로 돌아올 때 스크롤 위치를 복원한다.
+ *
+ * @param scrollContainerRef 스크롤 컨테이너 ref. 없으면 window 기준으로 동작.
+ */
+export function useScrollRestoration(
+  scrollContainerRef?: React.RefObject<HTMLElement | null>,
+) {
+  const { pathname } = useLocation();
+  const savedPathname = useRef<string>(pathname);
+
+  // 라우트 변경 시 이전 경로의 스크롤 위치 저장
+  useEffect(() => {
+    const prevPathname = savedPathname.current;
+
+    return () => {
+      const scrollY = scrollContainerRef?.current
+        ? scrollContainerRef.current.scrollTop
+        : window.scrollY;
+      try {
+        sessionStorage.setItem(getKey(prevPathname), String(scrollY));
+      } catch {
+        // sessionStorage 접근 불가 시 무시
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  // 라우트 진입 시 저장된 스크롤 위치 복원
+  useEffect(() => {
+    savedPathname.current = pathname;
+
+    let stored: string | null = null;
+    try {
+      stored = sessionStorage.getItem(getKey(pathname));
+    } catch {
+      // sessionStorage 접근 불가 시 무시
+    }
+
+    if (stored !== null) {
+      const scrollY = parseFloat(stored);
+      if (!Number.isNaN(scrollY)) {
+        requestAnimationFrame(() => {
+          if (scrollContainerRef?.current) {
+            scrollContainerRef.current.scrollTop = scrollY;
+          } else {
+            window.scrollTo(0, scrollY);
+          }
+        });
+      }
+    }
+  }, [pathname, scrollContainerRef]);
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { Header } from '../components/Header';
 import { HeroSection } from '../components/HeroSection';
 import { BottomNav } from '../components/BottomNav';
@@ -20,6 +21,8 @@ import { useAuth } from '../contexts/AuthContext';
 type FeedTab = 'forYou' | 'following' | 'tags';
 
 export function Home() {
+  useScrollRestoration();
+
   const { user: currentUser, isLoading: authLoading } = useAuth();
   const [trendingTeas, setTrendingTeas] = useState<Tea[]>([]);
   const [trendingCreators, setTrendingCreators] = useState<Array<{ id: number; name: string; profileImageUrl?: string | null; followerCount: number }>>([]);

--- a/src/pages/Saved.tsx
+++ b/src/pages/Saved.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { useNavigate } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { NoteCard } from '../components/NoteCard';
@@ -20,6 +21,8 @@ type SavedTab = 'notes' | 'posts' | 'teas';
 const PAGE_SIZE = 20;
 
 export function Saved() {
+  useScrollRestoration();
+
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<SavedTab>('notes');

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { usePullToRefreshForPage } from '../contexts/PullToRefreshContext';
+import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { Search as SearchIcon, Clock, X } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { Header } from '../components/Header';
@@ -34,6 +35,9 @@ const SECTION_TITLES: Record<string, string> = {
 };
 
 export function Search() {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  useScrollRestoration(scrollContainerRef);
+
   const [searchParams, setSearchParams] = useSearchParams();
 
   const { user } = useAuth();
@@ -237,7 +241,7 @@ export function Search() {
         showProfile
       />
 
-      <div className="flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-4">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-4">
         <div className="relative">
           <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground pointer-events-none" />
           <Input

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { NoteCard } from '../components/NoteCard';
@@ -34,6 +35,8 @@ import { InfiniteScrollSentinel } from '../components/InfiniteScrollSentinel';
 type SortType = 'latest' | 'rating';
 
 export function UserProfile() {
+  useScrollRestoration();
+
   const { id } = useParams();
   const navigate = useNavigate();
   const { user: currentUser, isLoading: authLoading } = useAuth();

--- a/src/pages/__tests__/Search.test.tsx
+++ b/src/pages/__tests__/Search.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { Search } from '../Search';
 import { renderWithRouter } from '../../test/renderWithRouter';
 
@@ -53,9 +53,19 @@ vi.mock('../../lib/api', () => ({
     getNewRankings: vi.fn(() => Promise.resolve(mockTeas)),
     getCuration: vi.fn(() => Promise.resolve(mockTeas)),
     getSellers: vi.fn(() => Promise.resolve({ sellers: mockSellers })),
+    getTrending: vi.fn(() => Promise.resolve(mockTeas)),
   },
   tagsApi: {
     getPopularTags: vi.fn(() => Promise.resolve(mockPopularTags)),
+  },
+  notesApi: {
+    getAll: vi.fn(() => Promise.resolve([])),
+  },
+  cellarApi: {
+    getAll: vi.fn(() => Promise.resolve([])),
+  },
+  authApi: {
+    getMe: vi.fn(() => Promise.resolve({ user: null })),
   },
 }));
 
@@ -90,15 +100,26 @@ const getNavigateSpy = () => {
 };
 
 describe('Search 페이지', () => {
-  it('탐색 섹션(인기, 신규, 맞춤차, 찻집)을 렌더링한다', async () => {
-    renderWithRouter(<Search />, { route: '/sasaek' });
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('탐색 탭으로 전환 시 인기/신규/맞춤차 섹션이 표시된다', async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithRouter(<Search />, { route: '/sasaek' });
+
+    // tab switcher is a flex row with 검색/탐색 buttons inside bg-muted rounded-lg
+    const tabContainer = container.querySelector('.bg-muted.rounded-lg');
+    const tabButtons = tabContainer ? Array.from(tabContainer.querySelectorAll('button')) : [];
+    const exploreTabBtn = tabButtons.find((b) => b.textContent === '탐색');
+    if (!exploreTabBtn) throw new Error('탐색 tab button not found');
+    await user.click(exploreTabBtn);
 
     await waitFor(() => {
-      expect(screen.getByText(/사랑받는 차/)).toBeInTheDocument();
-    });
-    expect(screen.getByText(/신규 차/)).toBeInTheDocument();
-    expect(screen.getByText(/맞춤차/)).toBeInTheDocument();
-    expect(screen.getByText(/찻집\/다실/)).toBeInTheDocument();
+      expect(screen.getAllByText(/사랑받는 차/).length).toBeGreaterThan(0);
+    }, { timeout: 3000 });
+    expect(screen.getAllByText(/신규 차/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/맞춤차/).length).toBeGreaterThan(0);
   });
 
   it('검색어와 일치하는 차를 렌더링한다', async () => {
@@ -122,8 +143,15 @@ describe('Search 페이지', () => {
     expect(await screen.findByText('검색 결과가 없어요.')).toBeInTheDocument();
   });
 
-  it('찻집/다실 섹션에 찻집 목록을 표시한다', async () => {
-    renderWithRouter(<Search />, { route: '/sasaek' });
+  it('탐색 탭에서 찻집/다실 목록을 표시한다', async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithRouter(<Search />, { route: '/sasaek' });
+
+    const tabContainer = container.querySelector('.bg-muted.rounded-lg');
+    const tabButtons = tabContainer ? Array.from(tabContainer.querySelectorAll('button')) : [];
+    const exploreTabBtn = tabButtons.find((b) => b.textContent === '탐색');
+    if (!exploreTabBtn) throw new Error('탐색 tab button not found');
+    await user.click(exploreTabBtn);
 
     await waitFor(() => {
       expect(screen.getByText('탐색전용샵')).toBeInTheDocument();
@@ -160,16 +188,39 @@ describe('Search 페이지', () => {
     expect(getNavigateSpy()).toHaveBeenCalledWith('/tea/new');
   });
 
-  it('필터 UI(차종, 평점, 정렬)가 검색 결과 시 표시된다', async () => {
-    const user = userEvent.setup();
+  it('필터 UI가 초기에도 표시된다 (검색어 없이도 필터 접근 가능)', async () => {
     renderWithRouter(<Search />, { route: '/sasaek' });
-
-    const input = screen.getByPlaceholderText('차 이름, 종류, 구매처로 검색...');
-    await user.type(input, '무이');
 
     await waitFor(() => {
       expect(screen.getByText('필터')).toBeInTheDocument();
     });
-    expect(screen.getByText('인기순')).toBeInTheDocument();
+  });
+
+  it('필터 패널을 클릭하면 정렬 옵션이 표시된다', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<Search />, { route: '/sasaek' });
+
+    const filterButton = await screen.findByText('필터');
+    await user.click(filterButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('인기순')).toBeInTheDocument();
+    });
+  });
+
+  it('검색어 없이 필터 적용 시 getWithFilters가 호출된다', async () => {
+    const { teasApi } = await import('../../lib/api');
+    const user = userEvent.setup();
+    renderWithRouter(<Search />, { route: '/sasaek' });
+
+    const filterButton = await screen.findByText('필터');
+    await user.click(filterButton);
+
+    const applyButton = await screen.findByRole('button', { name: '적용' });
+    await user.click(applyButton);
+
+    await waitFor(() => {
+      expect(teasApi.getWithFilters).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Closes #204
- Closes #221

### #204 검색어 없이 필터/정렬 적용
- `FilterPanel`이 검색어 없이도 항상 표시됨 (차 카테고리)
- 필터(차 종류, 평점, 정렬)를 선택하고 "적용" 클릭 시 검색어 없이도 `teasApi.getWithFilters` 호출
- `showResults` 조건이 `hasFilterParams`를 포함하여 URL 파라미터 기반으로 결과 표시

### #221 스크롤 위치 복원
- `src/hooks/useScrollRestoration.ts` 신규 생성
- `sessionStorage`에 pathname별 스크롤 위치 저장/복원
- 라우트 이탈 시 저장, 진입 시 `requestAnimationFrame`으로 복원
- 적용 페이지: **Home**, **Search** (scrollContainerRef), **UserProfile**, **Saved**
- Search는 `overflow-y-auto` 스크롤 컨테이너 ref 기준으로 동작

## Test plan
- [x] `npm run build` 통과
- [x] `useScrollRestoration.test.ts` 7개 테스트 신규 추가 및 통과
- [x] `Search.test.tsx` 업데이트 — authApi/notesApi/cellarApi mock 추가, 검색어 없는 필터 적용 케이스 추가
- [x] 총 16개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)