### PR TITLE
fix: AddTagCategory 마이그레이션 멱등성 처리로 프로덕션 실행 오류 해결

### DIFF
--- a/backend/migrations/1773474193846-AddTagCategory.ts
+++ b/backend/migrations/1773474193846-AddTagCategory.ts
@@ -3,29 +3,74 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class AddTagCategory1773474193846 implements MigrationInterface {
     name = 'AddTagCategory1773474193846'
 
+    private static readonly IDENTIFIER_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+    private validateIdentifier(value: string): void {
+        if (!AddTagCategory1773474193846.IDENTIFIER_PATTERN.test(value)) {
+            throw new Error(`Invalid SQL identifier: ${value}`);
+        }
+    }
+
+    private async dropIndexIfExists(queryRunner: QueryRunner, tableName: string, indexName: string): Promise<void> {
+        this.validateIdentifier(tableName);
+        this.validateIdentifier(indexName);
+        const result = await queryRunner.query(
+            `SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?`,
+            [tableName, indexName],
+        );
+        if (Number(result[0].cnt) > 0) {
+            await queryRunner.query(`DROP INDEX \`${indexName}\` ON \`${tableName}\``);
+        }
+    }
+
+    private async createIndexIfNotExists(queryRunner: QueryRunner, tableName: string, indexName: string, columns: string, unique = false): Promise<void> {
+        this.validateIdentifier(tableName);
+        this.validateIdentifier(indexName);
+        const result = await queryRunner.query(
+            `SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?`,
+            [tableName, indexName],
+        );
+        if (Number(result[0].cnt) === 0) {
+            const uniqueStr = unique ? 'UNIQUE ' : '';
+            await queryRunner.query(`CREATE ${uniqueStr}INDEX \`${indexName}\` ON \`${tableName}\` (${columns})`);
+        }
+    }
+
+    private async dropForeignKeyIfExists(queryRunner: QueryRunner, tableName: string, fkName: string): Promise<void> {
+        this.validateIdentifier(tableName);
+        this.validateIdentifier(fkName);
+        const result = await queryRunner.query(
+            `SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = ? AND CONSTRAINT_TYPE = 'FOREIGN KEY'`,
+            [tableName, fkName],
+        );
+        if (Number(result[0].cnt) > 0) {
+            await queryRunner.query(`ALTER TABLE \`${tableName}\` DROP FOREIGN KEY \`${fkName}\``);
+        }
+    }
+
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DROP INDEX \`FK_password_resets_userId\` ON \`password_resets\``);
-        await queryRunner.query(`DROP INDEX \`FK_posts_userId\` ON \`posts\``);
-        await queryRunner.query(`DROP INDEX \`FK_post_reports_reporterId\` ON \`post_reports\``);
-        await queryRunner.query(`DROP INDEX \`FK_comments_postId\` ON \`comments\``);
-        await queryRunner.query(`DROP INDEX \`FK_comments_userId\` ON \`comments\``);
-        await queryRunner.query(`DROP INDEX \`IDX_blind_session_participants_sessionId\` ON \`blind_session_participants\``);
-        await queryRunner.query(`DROP INDEX \`IDX_blind_session_participants_userId\` ON \`blind_session_participants\``);
-        await queryRunner.query(`DROP INDEX \`noteId\` ON \`blind_session_participants\``);
-        await queryRunner.query(`DROP INDEX \`UQ_blind_session_participants_session_user\` ON \`blind_session_participants\``);
-        await queryRunner.query(`DROP INDEX \`fk_bspn_note\` ON \`blind_session_participant_notes\``);
-        await queryRunner.query(`DROP INDEX \`fk_bspn_participant\` ON \`blind_session_participant_notes\``);
-        await queryRunner.query(`DROP INDEX \`fk_bspn_round\` ON \`blind_session_participant_notes\``);
-        await queryRunner.query(`DROP INDEX \`fk_bsr_session\` ON \`blind_session_rounds\``);
-        await queryRunner.query(`DROP INDEX \`fk_bsr_tea\` ON \`blind_session_rounds\``);
-        await queryRunner.query(`DROP INDEX \`IDX_blind_tasting_sessions_hostId\` ON \`blind_tasting_sessions\``);
-        await queryRunner.query(`DROP INDEX \`IDX_blind_tasting_sessions_status\` ON \`blind_tasting_sessions\``);
-        await queryRunner.query(`DROP INDEX \`teaId\` ON \`blind_tasting_sessions\``);
-        await queryRunner.query(`DROP INDEX \`UQ_blind_tasting_sessions_inviteCode\` ON \`blind_tasting_sessions\``);
-        await queryRunner.query(`DROP INDEX \`UQ_c25bc63d248ca90e8dcc1d92d06\` ON \`refresh_tokens\``);
-        await queryRunner.query(`DROP INDEX \`IDX_audit_logs_action\` ON \`audit_logs\``);
-        await queryRunner.query(`DROP INDEX \`IDX_audit_logs_adminId\` ON \`audit_logs\``);
-        await queryRunner.query(`DROP INDEX \`IDX_audit_logs_createdAt\` ON \`audit_logs\``);
+        await this.dropIndexIfExists(queryRunner, 'password_resets', 'FK_password_resets_userId');
+        await this.dropIndexIfExists(queryRunner, 'posts', 'FK_posts_userId');
+        await this.dropIndexIfExists(queryRunner, 'post_reports', 'FK_post_reports_reporterId');
+        await this.dropIndexIfExists(queryRunner, 'comments', 'FK_comments_postId');
+        await this.dropIndexIfExists(queryRunner, 'comments', 'FK_comments_userId');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_participants', 'IDX_blind_session_participants_sessionId');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_participants', 'IDX_blind_session_participants_userId');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_participants', 'noteId');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_participants', 'UQ_blind_session_participants_session_user');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_participant_notes', 'fk_bspn_note');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_participant_notes', 'fk_bspn_participant');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_participant_notes', 'fk_bspn_round');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_rounds', 'fk_bsr_session');
+        await this.dropIndexIfExists(queryRunner, 'blind_session_rounds', 'fk_bsr_tea');
+        await this.dropIndexIfExists(queryRunner, 'blind_tasting_sessions', 'IDX_blind_tasting_sessions_hostId');
+        await this.dropIndexIfExists(queryRunner, 'blind_tasting_sessions', 'IDX_blind_tasting_sessions_status');
+        await this.dropIndexIfExists(queryRunner, 'blind_tasting_sessions', 'teaId');
+        await this.dropIndexIfExists(queryRunner, 'blind_tasting_sessions', 'UQ_blind_tasting_sessions_inviteCode');
+        await this.dropIndexIfExists(queryRunner, 'refresh_tokens', 'UQ_c25bc63d248ca90e8dcc1d92d06');
+        await this.dropIndexIfExists(queryRunner, 'audit_logs', 'IDX_audit_logs_action');
+        await this.dropIndexIfExists(queryRunner, 'audit_logs', 'IDX_audit_logs_adminId');
+        await this.dropIndexIfExists(queryRunner, 'audit_logs', 'IDX_audit_logs_createdAt');
         // Add category column to tags (idempotent)
         const [colRows] = await queryRunner.query(`SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tags' AND COLUMN_NAME = 'category'`);
         if (Number(colRows.cnt) === 0) {
@@ -77,61 +122,61 @@ export class AddTagCategory1773474193846 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`blind_tasting_sessions\` DROP FOREIGN KEY \`FK_bf029e3e665d1b3c2866de83a25\``);
-        await queryRunner.query(`ALTER TABLE \`blind_tasting_sessions\` DROP FOREIGN KEY \`FK_bb54a646e566b4fc78a0336d15d\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_rounds\` DROP FOREIGN KEY \`FK_c0a5f55d3b0af62ea512f110329\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_rounds\` DROP FOREIGN KEY \`FK_2834aac794799727b55507845a8\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_participant_notes\` DROP FOREIGN KEY \`FK_0731579ea21abf3f3467ad67ee5\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_participant_notes\` DROP FOREIGN KEY \`FK_0cca861dfa108152f135df33dd9\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_participant_notes\` DROP FOREIGN KEY \`FK_41a1614b2edb16501fb3da0285f\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_participants\` DROP FOREIGN KEY \`FK_62f4b02ff699eb737a218e05c36\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_participants\` DROP FOREIGN KEY \`FK_cc08133acd21548c252d85c1878\``);
-        await queryRunner.query(`ALTER TABLE \`blind_session_participants\` DROP FOREIGN KEY \`FK_eb77aa981951b86b443635e90aa\``);
-        await queryRunner.query(`ALTER TABLE \`post_images\` DROP FOREIGN KEY \`FK_92e2382a7f43d4e9350d591fb6a\``);
-        await queryRunner.query(`ALTER TABLE \`tea_sessions\` DROP FOREIGN KEY \`FK_c9ffb463a670be3b398b9d9321e\``);
-        await queryRunner.query(`ALTER TABLE \`tea_sessions\` DROP FOREIGN KEY \`FK_e2fd96d3530a0950e35c7d06b33\``);
-        await queryRunner.query(`ALTER TABLE \`tea_sessions\` DROP FOREIGN KEY \`FK_8f928a87387a4332e80ba51ce56\``);
-        await queryRunner.query(`ALTER TABLE \`tea_session_steeps\` DROP FOREIGN KEY \`FK_faf4e470429cd6e70cce197e253\``);
-        await queryRunner.query(`ALTER TABLE \`tea_wishlists\` DROP FOREIGN KEY \`FK_485ebd115d7891009ef74142ca9\``);
-        await queryRunner.query(`ALTER TABLE \`tea_wishlists\` DROP FOREIGN KEY \`FK_3f82647610d8c8964b4edbda603\``);
-        await queryRunner.query(`ALTER TABLE \`teas\` DROP FOREIGN KEY \`FK_1c485b6b74287fbc93221ff305c\``);
-        await queryRunner.query(`ALTER TABLE \`note_schemas\` DROP FOREIGN KEY \`FK_99116e60a8543f91cbde0aad562\``);
-        await queryRunner.query(`ALTER TABLE \`note_schemas\` DROP FOREIGN KEY \`FK_2cb2d20d688b9bb828dd6ff566b\``);
-        await queryRunner.query(`ALTER TABLE \`password_resets\` DROP FOREIGN KEY \`FK_d95569f623f28a0bf034a55099e\``);
-        await queryRunner.query(`DROP INDEX \`IDX_92e2382a7f43d4e9350d591fb6\` ON \`post_images\``);
-        await queryRunner.query(`DROP INDEX \`IDX_f6d2e7bbe89d4d2bb8d9aeaba9\` ON \`tea_wishlists\``);
-        await queryRunner.query(`DROP INDEX \`IDX_3f82647610d8c8964b4edbda60\` ON \`tea_wishlists\``);
-        await queryRunner.query(`DROP INDEX \`IDX_485ebd115d7891009ef74142ca\` ON \`tea_wishlists\``);
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_tasting_sessions', 'FK_bf029e3e665d1b3c2866de83a25');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_tasting_sessions', 'FK_bb54a646e566b4fc78a0336d15d');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_rounds', 'FK_c0a5f55d3b0af62ea512f110329');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_rounds', 'FK_2834aac794799727b55507845a8');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_participant_notes', 'FK_0731579ea21abf3f3467ad67ee5');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_participant_notes', 'FK_0cca861dfa108152f135df33dd9');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_participant_notes', 'FK_41a1614b2edb16501fb3da0285f');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_participants', 'FK_62f4b02ff699eb737a218e05c36');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_participants', 'FK_cc08133acd21548c252d85c1878');
+        await this.dropForeignKeyIfExists(queryRunner, 'blind_session_participants', 'FK_eb77aa981951b86b443635e90aa');
+        await this.dropForeignKeyIfExists(queryRunner, 'post_images', 'FK_92e2382a7f43d4e9350d591fb6a');
+        await this.dropForeignKeyIfExists(queryRunner, 'tea_sessions', 'FK_c9ffb463a670be3b398b9d9321e');
+        await this.dropForeignKeyIfExists(queryRunner, 'tea_sessions', 'FK_e2fd96d3530a0950e35c7d06b33');
+        await this.dropForeignKeyIfExists(queryRunner, 'tea_sessions', 'FK_8f928a87387a4332e80ba51ce56');
+        await this.dropForeignKeyIfExists(queryRunner, 'tea_session_steeps', 'FK_faf4e470429cd6e70cce197e253');
+        await this.dropForeignKeyIfExists(queryRunner, 'tea_wishlists', 'FK_485ebd115d7891009ef74142ca9');
+        await this.dropForeignKeyIfExists(queryRunner, 'tea_wishlists', 'FK_3f82647610d8c8964b4edbda603');
+        await this.dropForeignKeyIfExists(queryRunner, 'teas', 'FK_1c485b6b74287fbc93221ff305c');
+        await this.dropForeignKeyIfExists(queryRunner, 'note_schemas', 'FK_99116e60a8543f91cbde0aad562');
+        await this.dropForeignKeyIfExists(queryRunner, 'note_schemas', 'FK_2cb2d20d688b9bb828dd6ff566b');
+        await this.dropForeignKeyIfExists(queryRunner, 'password_resets', 'FK_d95569f623f28a0bf034a55099e');
+        await this.dropIndexIfExists(queryRunner, 'post_images', 'IDX_92e2382a7f43d4e9350d591fb6');
+        await this.dropIndexIfExists(queryRunner, 'tea_wishlists', 'IDX_f6d2e7bbe89d4d2bb8d9aeaba9');
+        await this.dropIndexIfExists(queryRunner, 'tea_wishlists', 'IDX_3f82647610d8c8964b4edbda60');
+        await this.dropIndexIfExists(queryRunner, 'tea_wishlists', 'IDX_485ebd115d7891009ef74142ca');
         await queryRunner.query(`ALTER TABLE \`refresh_tokens\` CHANGE \`createdAt\` \`createdAt\` datetime(0) NOT NULL DEFAULT CURRENT_TIMESTAMP`);
-        await queryRunner.query(`ALTER TABLE \`refresh_tokens\` DROP INDEX \`IDX_c25bc63d248ca90e8dcc1d92d0\``);
+        await this.dropIndexIfExists(queryRunner, 'refresh_tokens', 'IDX_c25bc63d248ca90e8dcc1d92d0');
         await queryRunner.query(`ALTER TABLE \`refresh_tokens\` DROP COLUMN \`tokenHash\``);
         await queryRunner.query(`ALTER TABLE \`refresh_tokens\` ADD \`tokenHash\` varchar(64) NOT NULL`);
         await queryRunner.query(`ALTER TABLE \`blind_tasting_sessions\` CHANGE \`createdAt\` \`createdAt\` datetime(0) NOT NULL DEFAULT CURRENT_TIMESTAMP`);
         await queryRunner.query(`ALTER TABLE \`tea_wishlists\` CHANGE \`createdAt\` \`createdAt\` datetime(0) NOT NULL DEFAULT CURRENT_TIMESTAMP`);
         await queryRunner.query(`ALTER TABLE \`note_schemas\` CHANGE \`createdAt\` \`createdAt\` datetime(0) NOT NULL DEFAULT CURRENT_TIMESTAMP`);
-        await queryRunner.query(`ALTER TABLE \`password_resets\` DROP INDEX \`IDX_7f6aae0fcc807c9e7194ca5cc4\``);
-        await queryRunner.query(`CREATE INDEX \`IDX_audit_logs_createdAt\` ON \`audit_logs\` (\`createdAt\`)`);
-        await queryRunner.query(`CREATE INDEX \`IDX_audit_logs_adminId\` ON \`audit_logs\` (\`adminId\`)`);
-        await queryRunner.query(`CREATE INDEX \`IDX_audit_logs_action\` ON \`audit_logs\` (\`action\`)`);
-        await queryRunner.query(`CREATE UNIQUE INDEX \`UQ_c25bc63d248ca90e8dcc1d92d06\` ON \`refresh_tokens\` (\`tokenHash\`)`);
-        await queryRunner.query(`CREATE UNIQUE INDEX \`UQ_blind_tasting_sessions_inviteCode\` ON \`blind_tasting_sessions\` (\`inviteCode\`)`);
-        await queryRunner.query(`CREATE INDEX \`teaId\` ON \`blind_tasting_sessions\` (\`teaId\`)`);
-        await queryRunner.query(`CREATE INDEX \`IDX_blind_tasting_sessions_status\` ON \`blind_tasting_sessions\` (\`status\`)`);
-        await queryRunner.query(`CREATE INDEX \`IDX_blind_tasting_sessions_hostId\` ON \`blind_tasting_sessions\` (\`hostId\`)`);
-        await queryRunner.query(`CREATE INDEX \`fk_bsr_tea\` ON \`blind_session_rounds\` (\`teaId\`)`);
-        await queryRunner.query(`CREATE INDEX \`fk_bsr_session\` ON \`blind_session_rounds\` (\`sessionId\`)`);
-        await queryRunner.query(`CREATE INDEX \`fk_bspn_round\` ON \`blind_session_participant_notes\` (\`roundId\`)`);
-        await queryRunner.query(`CREATE INDEX \`fk_bspn_participant\` ON \`blind_session_participant_notes\` (\`participantId\`)`);
-        await queryRunner.query(`CREATE INDEX \`fk_bspn_note\` ON \`blind_session_participant_notes\` (\`noteId\`)`);
-        await queryRunner.query(`CREATE UNIQUE INDEX \`UQ_blind_session_participants_session_user\` ON \`blind_session_participants\` (\`sessionId\`, \`userId\`)`);
-        await queryRunner.query(`CREATE INDEX \`noteId\` ON \`blind_session_participants\` (\`noteId\`)`);
-        await queryRunner.query(`CREATE INDEX \`IDX_blind_session_participants_userId\` ON \`blind_session_participants\` (\`userId\`)`);
-        await queryRunner.query(`CREATE INDEX \`IDX_blind_session_participants_sessionId\` ON \`blind_session_participants\` (\`sessionId\`)`);
-        await queryRunner.query(`CREATE INDEX \`FK_comments_userId\` ON \`comments\` (\`userId\`)`);
-        await queryRunner.query(`CREATE INDEX \`FK_comments_postId\` ON \`comments\` (\`postId\`)`);
-        await queryRunner.query(`CREATE INDEX \`FK_post_reports_reporterId\` ON \`post_reports\` (\`reporterId\`)`);
-        await queryRunner.query(`CREATE INDEX \`FK_posts_userId\` ON \`posts\` (\`userId\`)`);
-        await queryRunner.query(`CREATE INDEX \`FK_password_resets_userId\` ON \`password_resets\` (\`userId\`)`);
+        await this.dropIndexIfExists(queryRunner, 'password_resets', 'IDX_7f6aae0fcc807c9e7194ca5cc4');
+        await this.createIndexIfNotExists(queryRunner, 'audit_logs', 'IDX_audit_logs_createdAt', '`createdAt`');
+        await this.createIndexIfNotExists(queryRunner, 'audit_logs', 'IDX_audit_logs_adminId', '`adminId`');
+        await this.createIndexIfNotExists(queryRunner, 'audit_logs', 'IDX_audit_logs_action', '`action`');
+        await this.createIndexIfNotExists(queryRunner, 'refresh_tokens', 'UQ_c25bc63d248ca90e8dcc1d92d06', '`tokenHash`', true);
+        await this.createIndexIfNotExists(queryRunner, 'blind_tasting_sessions', 'UQ_blind_tasting_sessions_inviteCode', '`inviteCode`', true);
+        await this.createIndexIfNotExists(queryRunner, 'blind_tasting_sessions', 'teaId', '`teaId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_tasting_sessions', 'IDX_blind_tasting_sessions_status', '`status`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_tasting_sessions', 'IDX_blind_tasting_sessions_hostId', '`hostId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_rounds', 'fk_bsr_tea', '`teaId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_rounds', 'fk_bsr_session', '`sessionId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_participant_notes', 'fk_bspn_round', '`roundId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_participant_notes', 'fk_bspn_participant', '`participantId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_participant_notes', 'fk_bspn_note', '`noteId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_participants', 'UQ_blind_session_participants_session_user', '`sessionId`, `userId`', true);
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_participants', 'noteId', '`noteId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_participants', 'IDX_blind_session_participants_userId', '`userId`');
+        await this.createIndexIfNotExists(queryRunner, 'blind_session_participants', 'IDX_blind_session_participants_sessionId', '`sessionId`');
+        await this.createIndexIfNotExists(queryRunner, 'comments', 'FK_comments_userId', '`userId`');
+        await this.createIndexIfNotExists(queryRunner, 'comments', 'FK_comments_postId', '`postId`');
+        await this.createIndexIfNotExists(queryRunner, 'post_reports', 'FK_post_reports_reporterId', '`reporterId`');
+        await this.createIndexIfNotExists(queryRunner, 'posts', 'FK_posts_userId', '`userId`');
+        await this.createIndexIfNotExists(queryRunner, 'password_resets', 'FK_password_resets_userId', '`userId`');
         await queryRunner.query(`ALTER TABLE \`tags\` DROP COLUMN \`category\``);
     }
 


### PR DESCRIPTION
## Summary
- 프로덕션 DB에서 `AddTagCategory1773474193846` 마이그레이션 실행 시 `FK_password_resets_userId` 인덱스가 존재하지 않아 실패하는 오류 수정
- `INFORMATION_SCHEMA` 조회 후 조건부 실행하는 idempotent 헬퍼 메서드 3개 도입:
  - `dropIndexIfExists` — 인덱스 존재 시에만 DROP
  - `createIndexIfNotExists` — 인덱스 미존재 시에만 CREATE
  - `dropForeignKeyIfExists` — FK 존재 시에만 DROP
- SQL identifier 검증 추가 (방어적 코딩)
- `up()`, `down()` 모두 멱등성 처리 완료

## Test plan
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `npm run build` (nest build) 성공
- [ ] 프로덕션 서버에서 `npm run migration:run` 재실행하여 마이그레이션 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 태그에 카테고리 기능이 추가되었습니다.
  * 새로운 플레이버 태그 데이터가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->