### PR TITLE
fix: 캘린더 API 날짜 포맷 YYYY-MM-DD 정규화

### DIFF
--- a/backend/src/notes/notes.service.spec.ts
+++ b/backend/src/notes/notes.service.spec.ts
@@ -757,6 +757,27 @@ describe('NotesService', () => {
       expect(typeof result.streak.current).toBe('number');
       expect(typeof result.streak.longest).toBe('number');
     });
+
+    it('DATE()가 Date 객체를 반환해도 YYYY-MM-DD 문자열로 변환해야 함', async () => {
+      const calendarQb = makeQb([
+        { date: new Date(2026, 2, 10) },
+        { date: new Date(2026, 2, 15) },
+      ]);
+      const streakQb = makeQb([
+        { date: '2026-03-15' },
+        { date: '2026-03-10' },
+      ]);
+      mockNotesRepository.createQueryBuilder
+        .mockReturnValueOnce(calendarQb)
+        .mockReturnValueOnce(streakQb);
+
+      const result = await service.getCalendarData(1, 2026, 3);
+
+      expect(result.dates).toEqual(['2026-03-10', '2026-03-15']);
+      result.dates.forEach((d) => {
+        expect(d).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      });
+    });
   });
 
   describe('calculateStreak', () => {

--- a/backend/src/notes/notes.service.ts
+++ b/backend/src/notes/notes.service.ts
@@ -922,10 +922,20 @@ export class NotesService {
       .orderBy('date', 'ASC')
       .getRawMany<{ date: string }>();
 
-    const dates = rows.map((r) => r.date);
+    const dates = rows.map((r) => this.normalizeRawDate(r.date));
     const streak = await this.calculateStreak(userId);
 
     return { dates, streak };
+  }
+
+  private normalizeRawDate(raw: unknown): string {
+    if (raw instanceof Date) {
+      const y = raw.getFullYear();
+      const m = String(raw.getMonth() + 1).padStart(2, '0');
+      const d = String(raw.getDate()).padStart(2, '0');
+      return `${y}-${m}-${d}`;
+    }
+    return String(raw).slice(0, 10);
   }
 
   async calculateStreak(userId: number): Promise<{ current: number; longest: number }> {
@@ -950,7 +960,7 @@ export class NotesService {
     let prevDate: Date | null = null;
 
     for (const row of rows) {
-      const d = new Date(row.date);
+      const d = new Date(this.normalizeRawDate(row.date));
       d.setHours(0, 0, 0, 0);
 
       if (prevDate === null) {


### PR DESCRIPTION
## Summary
- 캘린더 API가 `"2026-03-10T00:00:00.000Z"` 대신 `"2026-03-10"` 반환하도록 수정
- TypeORM `getRawMany`가 `DATE()`를 Date 객체로 반환하는 경우 대응
- 로컬 타임존 기반 `normalizeRawDate` 헬퍼 추출 (`toISOString` 대신 `getFullYear/getMonth/getDate` 사용)
- `getCalendarData` + `calculateStreak` 모두 적용

## Test plan
- [x] 기존 테스트 통과
- [x] Date 객체 → YYYY-MM-DD 변환 테스트 추가 (로컬 타임존 기준)
- [x] `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)