### PR TITLE
feat: 캘린더 날짜 클릭 시 차록 목록 바텀 드로어

### DIFF
--- a/backend/src/notes/notes.controller.ts
+++ b/backend/src/notes/notes.controller.ts
@@ -116,6 +116,22 @@ export class NotesController {
   }
 
   @UseGuards(OptionalJwtAuthGuard)
+  @Get('by-date')
+  async findByDate(
+    @Query('userId') userId: string,
+    @Query('date') date: string,
+    @Request() req?: any,
+  ) {
+    const userIdNum = parseInt(userId, 10);
+    if (Number.isNaN(userIdNum) || !date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new BadRequestException('userId(number)와 date(YYYY-MM-DD)가 필요합니다.');
+    }
+    const currentUserId = req?.user?.userId ? parseInt(req.user.userId, 10) : undefined;
+    const isOwner = currentUserId === userIdNum;
+    return this.notesService.findByDate(userIdNum, date, isOwner);
+  }
+
+  @UseGuards(OptionalJwtAuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string, @Request() req) {
     const parsedId = parseInt(id, 10);

--- a/backend/src/notes/notes.service.spec.ts
+++ b/backend/src/notes/notes.service.spec.ts
@@ -780,6 +780,33 @@ describe('NotesService', () => {
     });
   });
 
+  describe('findByDate', () => {
+    it('특정 날짜의 노트 목록을 반환해야 함', async () => {
+      const mockNotes = [
+        { id: 1, createdAt: new Date('2026-03-10T05:00:00Z'), user: { id: 1 }, tea: { id: 1 } },
+        { id: 2, createdAt: new Date('2026-03-10T12:00:00Z'), user: { id: 1 }, tea: { id: 2 } },
+      ];
+      const qb = makeQb([]);
+      qb.getMany.mockResolvedValueOnce(mockNotes);
+      mockNotesRepository.createQueryBuilder.mockReturnValueOnce(qb);
+
+      const result = await service.findByDate(1, '2026-03-10');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(1);
+    });
+
+    it('노트가 없으면 빈 배열을 반환해야 함', async () => {
+      const qb = makeQb([]);
+      qb.getMany.mockResolvedValueOnce([]);
+      mockNotesRepository.createQueryBuilder.mockReturnValueOnce(qb);
+
+      const result = await service.findByDate(1, '2026-03-11');
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('calculateStreak', () => {
     it('노트가 없을 때 0,0을 반환해야 함', async () => {
       mockNotesRepository.createQueryBuilder.mockReturnValueOnce(makeQb([]));

--- a/backend/src/notes/notes.service.ts
+++ b/backend/src/notes/notes.service.ts
@@ -928,6 +928,23 @@ export class NotesService {
     return { dates, streak };
   }
 
+  async findByDate(userId: number, date: string, isOwner = false): Promise<any[]> {
+    const startOfDay = new Date(`${date}T00:00:00`);
+    const endOfDay = new Date(`${date}T23:59:59.999`);
+
+    const qb = this.buildListQueryBuilder()
+      .where('note.userId = :userId', { userId })
+      .andWhere('note.createdAt >= :startOfDay', { startOfDay })
+      .andWhere('note.createdAt <= :endOfDay', { endOfDay })
+      .orderBy('note.createdAt', 'DESC');
+
+    if (!isOwner) {
+      qb.andWhere('note.isPublic = :isPublic', { isPublic: true });
+    }
+
+    return qb.getMany();
+  }
+
   private normalizeRawDate(raw: unknown): string {
     if (raw instanceof Date) {
       const y = raw.getFullYear();

--- a/src/lib/api/notes.api.ts
+++ b/src/lib/api/notes.api.ts
@@ -1,4 +1,4 @@
-import { RatingSchema } from '../../types';
+import { RatingSchema, Note } from '../../types';
 import { apiClient } from './client';
 import { ReportReason } from './users.api';
 
@@ -80,4 +80,6 @@ export const notesApi = {
   report: (id: number, reason: ReportReason) => apiClient.post<{ id: number; message: string }>(`/notes/${id}/report`, { reason }),
   getCalendar: (userId: number, year: number, month: number) =>
     apiClient.get<CalendarData>(`/notes/calendar?userId=${userId}&year=${year}&month=${month}`),
+  getByDate: (userId: number, date: string) =>
+    apiClient.get<Note[]>(`/notes/by-date?userId=${userId}&date=${date}`),
 };

--- a/src/pages/TeaCalendar.tsx
+++ b/src/pages/TeaCalendar.tsx
@@ -1,14 +1,29 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { CalendarDays, Flame, Trophy, ChevronLeft, ChevronRight } from 'lucide-react';
+import { CalendarDays, Flame, Trophy, ChevronLeft, ChevronRight, Plus, Loader2 } from 'lucide-react';
 import { Header } from '../components/Header';
 import { BottomNav } from '../components/BottomNav';
 import { Calendar } from '../components/ui/calendar';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '../components/ui/drawer';
+import { NoteCard } from '../components/NoteCard';
 import { notesApi } from '../lib/api';
 import type { CalendarData } from '../lib/api/notes.api';
+import type { Note } from '../types';
 import { useAuth } from '../contexts/AuthContext';
-import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+function formatDateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function formatDateLabel(date: Date): string {
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  const day = DAY_NAMES[date.getDay()];
+  return `${m}월 ${d}일(${day})`;
+}
 
 export function TeaCalendar() {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -19,6 +34,11 @@ export function TeaCalendar() {
   const [month, setMonth] = useState(now.getMonth() + 1);
   const [calendarData, setCalendarData] = useState<CalendarData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [dateNotes, setDateNotes] = useState<Note[]>([]);
+  const [isLoadingNotes, setIsLoadingNotes] = useState(false);
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -43,6 +63,22 @@ export function TeaCalendar() {
     fetchCalendar();
   }, [fetchCalendar]);
 
+  const handleDayClick = useCallback(async (date: Date) => {
+    if (!user) return;
+    setSelectedDate(date);
+    setDrawerOpen(true);
+    setIsLoadingNotes(true);
+    setDateNotes([]);
+    try {
+      const notes = await notesApi.getByDate(user.id, formatDateKey(date));
+      setDateNotes(notes);
+    } catch {
+      toast.error('차록을 불러오지 못했습니다.');
+    } finally {
+      setIsLoadingNotes(false);
+    }
+  }, [user]);
+
   const goToPrevMonth = () => {
     if (month === 1) {
       setYear((y) => y - 1);
@@ -64,10 +100,7 @@ export function TeaCalendar() {
   const noteDates = new Set(calendarData?.dates ?? []);
 
   const modifiers = {
-    hasNote: (date: Date) => {
-      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-      return noteDates.has(key);
-    },
+    hasNote: (date: Date) => noteDates.has(formatDateKey(date)),
   };
 
   const modifiersClassNames = {
@@ -138,6 +171,7 @@ export function TeaCalendar() {
                 setYear(d.getFullYear());
                 setMonth(d.getMonth() + 1);
               }}
+              onDayClick={handleDayClick}
               modifiers={modifiers}
               modifiersClassNames={modifiersClassNames}
               showOutsideDays={false}
@@ -152,6 +186,52 @@ export function TeaCalendar() {
           </p>
         )}
       </div>
+
+      {/* Date Notes Drawer */}
+      <Drawer open={drawerOpen} onOpenChange={setDrawerOpen}>
+        <DrawerContent className="max-h-[80vh]">
+          <DrawerHeader className="flex items-center justify-between px-4 py-3 border-b">
+            <DrawerTitle className="text-lg font-semibold">
+              {selectedDate ? formatDateLabel(selectedDate) : ''}
+            </DrawerTitle>
+            <button
+              onClick={() => {
+                setDrawerOpen(false);
+                navigate('/note/new');
+              }}
+              className="text-primary font-medium text-sm flex items-center gap-1"
+            >
+              <Plus className="w-4 h-4" />
+              기록 추가
+            </button>
+          </DrawerHeader>
+
+          <div className="overflow-y-auto px-4 py-3 space-y-3">
+            {isLoadingNotes ? (
+              <div className="flex justify-center py-8">
+                <Loader2 className="w-6 h-6 text-primary animate-spin" />
+              </div>
+            ) : dateNotes.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground">
+                <p className="text-sm">이 날의 차록이 없습니다.</p>
+                <button
+                  onClick={() => {
+                    setDrawerOpen(false);
+                    navigate('/note/new');
+                  }}
+                  className="mt-3 text-primary font-medium text-sm"
+                >
+                  차록 작성하기
+                </button>
+              </div>
+            ) : (
+              dateNotes.map((note) => (
+                <NoteCard key={note.id} note={note} showTeaName />
+              ))
+            )}
+          </div>
+        </DrawerContent>
+      </Drawer>
 
       <BottomNav />
     </div>


### PR DESCRIPTION
## Summary
- 백엔드: `GET /notes/by-date?userId=&date=YYYY-MM-DD` 엔드포인트 추가
- 비공개 노트는 소유자만 조회 가능 (OptionalJwtAuthGuard + isOwner 권한 체크)
- 프론트엔드: 캘린더 날짜 클릭 → Vaul Drawer에 NoteCard 리스트 표시
- 로딩/빈 상태/노트 리스트 3가지 상태 처리
- "기록 추가" 버튼으로 차록 작성 페이지 이동

## Test plan
- [x] `findByDate` 단위 테스트 2개 통과 (23/23)
- [x] 프론트엔드 빌드 성공
- [x] 백엔드 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캘린더에서 날짜를 클릭하여 해당 날짜의 노트를 확인할 수 있습니다.
  * 선택한 날짜의 노트가 드로어 형식으로 표시됩니다.
  * 노트가 없는 경우 해당 날짜에 새 노트를 생성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->