### PR TITLE
fix: AdminJS Vite 프록시 추가

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -104,6 +104,10 @@ import path from 'path';
           // 백엔드에 setGlobalPrefix('api')가 설정되어 있으므로 rewrite 제거
           // 프론트엔드: /api/teas -> 백엔드: /api/teas
         },
+        '/adminjs': {
+          target: 'http://localhost:3000',
+          changeOrigin: true,
+        },
       },
     },
     test: {


### PR DESCRIPTION
## Summary
- `/adminjs` 경로를 백엔드(localhost:3000)로 프록시 추가
- 개발 환경에서 `http://localhost:5173/adminjs` 접근 가능

## Test plan
- [x] `npm run build` 성공
- [ ] `npm run dev:local`로 AdminJS 페이지 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)