### PR TITLE
feat: #265 차록에 날짜 및 날씨 표시 기능 추가

### DIFF
--- a/backend/migrations/1773633029395-AddDrinkDateToNotes.ts
+++ b/backend/migrations/1773633029395-AddDrinkDateToNotes.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDrinkDateToNotes1773633029395 implements MigrationInterface {
+    name = 'AddDrinkDateToNotes1773633029395'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const cols = await queryRunner.query(
+            `SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'notes' AND COLUMN_NAME = 'drinkDate'`,
+        );
+        if (Number(cols[0].cnt) === 0) {
+            await queryRunner.query(`ALTER TABLE \`notes\` ADD \`drinkDate\` date NULL`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const cols = await queryRunner.query(
+            `SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'notes' AND COLUMN_NAME = 'drinkDate'`,
+        );
+        if (Number(cols[0].cnt) > 0) {
+            await queryRunner.query(`ALTER TABLE \`notes\` DROP COLUMN \`drinkDate\``);
+        }
+    }
+}

--- a/backend/src/notes/dto/create-note.dto.ts
+++ b/backend/src/notes/dto/create-note.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNumber, Min, Max, IsBoolean, ValidateNested, IsOptional, IsArray, ArrayMaxSize, MaxLength, registerDecorator, ValidationOptions } from 'class-validator';
+import { IsString, IsNumber, Min, Max, IsBoolean, ValidateNested, IsOptional, IsArray, ArrayMaxSize, MaxLength, Matches, registerDecorator, ValidationOptions } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import { VALIDATION } from '../../common/constants/validation';
 
@@ -93,6 +93,12 @@ export class CreateNoteDto {
   @ArrayMaxSize(10, { message: 'tags must contain at most 10 items' })
   @IsString({ each: true, message: 'each tag must be a string' })
   tags?: string[];
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'drinkDate는 YYYY-MM-DD 형식이어야 합니다' })
+  @Transform(({ value }) => value === null ? null : value)
+  drinkDate?: string | null;
 
   @IsBoolean()
   isPublic: boolean;

--- a/backend/src/notes/entities/note.entity.ts
+++ b/backend/src/notes/entities/note.entity.ts
@@ -50,6 +50,9 @@ export class Note {
   @Column({ type: 'json', nullable: true })
   imageThumbnails: string[] | null;
 
+  @Column({ type: 'date', nullable: true })
+  drinkDate: string | null;
+
   @Column({ default: false })
   isPublic: boolean;
 

--- a/src/hooks/useNoteForm.ts
+++ b/src/hooks/useNoteForm.ts
@@ -40,6 +40,7 @@ export function useNoteForm({
   const [images, setImages] = useState<string[]>([]);
   const [imageThumbnails, setImageThumbnails] = useState<(string | null)[]>([]);
   const [tags, setTags] = useState<string[]>([]);
+  const [drinkDate, setDrinkDate] = useState<string>(new Date().toISOString().slice(0, 10));
   const [isPublic, setIsPublic] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [addTemplateOpen, setAddTemplateOpen] = useState(false);
@@ -164,6 +165,9 @@ export function useNoteForm({
             : noteImages.map(() => null),
         );
         setTags(normalizedNote.tags || []);
+        if (normalizedNote.drinkDate) {
+          setDrinkDate(String(normalizedNote.drinkDate).slice(0, 10));
+        }
         setIsPublic(normalizedNote.isPublic);
       } catch (error: unknown) {
         logger.error('Failed to fetch note:', error);
@@ -316,6 +320,7 @@ export function useNoteForm({
           images: imagePayload,
           imageThumbnails: thumbnailPayload,
           tags: tags.length > 0 ? tags : undefined,
+          drinkDate: drinkDate || undefined,
           isPublic,
         });
         toast.success('기록이 저장되었습니다.');
@@ -337,6 +342,7 @@ export function useNoteForm({
           images: imagePayload,
           imageThumbnails: thumbnailPayload,
           tags: tags.length > 0 ? tags : undefined,
+          drinkDate: drinkDate || undefined,
           isPublic,
         });
         toast.success('차록이 수정되었습니다.');
@@ -381,6 +387,8 @@ export function useNoteForm({
     },
     tags,
     setTags,
+    drinkDate,
+    setDrinkDate,
     isPublic,
     setIsPublic,
     // ui state

--- a/src/pages/NewNote.tsx
+++ b/src/pages/NewNote.tsx
@@ -45,6 +45,8 @@ export function NewNote() {
     setImagesAndThumbnails,
     tags,
     setTags,
+    drinkDate,
+    setDrinkDate,
     isPublic,
     setIsPublic,
     isSaving,
@@ -148,6 +150,17 @@ export function NewNote() {
                 imageThumbnails={imageThumbnails}
                 onChange={setImagesAndThumbnails}
                 maxImages={5}
+              />
+            </section>
+
+            <section className="bg-card rounded-lg p-4">
+              <Label className="mb-2 block">음용 날짜</Label>
+              <input
+                type="date"
+                value={drinkDate}
+                onChange={(e) => setDrinkDate(e.target.value)}
+                max={new Date().toISOString().slice(0, 10)}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
               />
             </section>
 

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -29,6 +29,7 @@ import { useShare } from '../hooks/useShare';
 import { TeaTypeBadge } from '../components/TeaTypeBadge';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { fetchWeather, type WeatherInfo } from '../utils/weather';
 
 export function NoteDetail() {
   const { id } = useParams();
@@ -47,6 +48,7 @@ export function NoteDetail() {
   const [isTogglingLike, setIsTogglingLike] = useState(false);
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isTogglingBookmark, setIsTogglingBookmark] = useState(false);
+  const [weather, setWeather] = useState<WeatherInfo | null>(null);
   const [showReportModal, setShowReportModal] = useState(false);
   const [use10Scale, setUse10Scale] = useState(false);
   const { share } = useShare();
@@ -85,6 +87,17 @@ export function NoteDetail() {
     if (isDeleted) return;
     fetchData();
   }, [noteId, isDeleted, fetchData]);
+
+  const weatherDateStr = note?.drinkDate
+    ? String(note.drinkDate).slice(0, 10)
+    : note?.createdAt
+      ? (note.createdAt instanceof Date ? note.createdAt.toISOString().slice(0, 10) : String(note.createdAt).slice(0, 10))
+      : null;
+
+  useEffect(() => {
+    if (!weatherDateStr) return;
+    fetchWeather(weatherDateStr).then(setWeather).catch(() => {});
+  }, [weatherDateStr]);
 
   if (isLoading) {
     return (
@@ -311,6 +324,14 @@ export function NoteDetail() {
 
           </div>
           
+          {note.drinkDate && (
+            <p className="text-sm mb-2">
+              {weather ? `${weather.emoji} ` : ''}
+              {new Date(note.drinkDate + 'T00:00:00').toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
+              {weather ? ` ${weather.label}` : ''}
+              {weather?.temperatureMin != null && weather?.temperatureMax != null && ` ${weather.temperatureMin}°~${weather.temperatureMax}°`}
+            </p>
+          )}
           <p className="text-xs text-muted-foreground mb-4">
             {note.createdAt.toLocaleDateString('ko-KR')} ·{' '}
             <button

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -135,6 +135,7 @@ export interface Note {
   images?: string[] | null;
   imageThumbnails?: string[] | null;
   tags?: string[] | null;
+  drinkDate?: string | null;
   isPublic: boolean;
   createdAt: Date;
   likeCount?: number;

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -1,0 +1,68 @@
+const WMO_CODE_MAP: Record<number, { emoji: string; label: string }> = {
+  0: { emoji: '☀️', label: '맑음' },
+  1: { emoji: '🌤️', label: '대체로 맑음' },
+  2: { emoji: '⛅', label: '구름 조금' },
+  3: { emoji: '☁️', label: '흐림' },
+  45: { emoji: '🌫️', label: '안개' },
+  48: { emoji: '🌫️', label: '안개' },
+  51: { emoji: '🌧️', label: '이슬비' },
+  53: { emoji: '🌧️', label: '이슬비' },
+  55: { emoji: '🌧️', label: '이슬비' },
+  56: { emoji: '🌧️', label: '진눈깨비' },
+  57: { emoji: '🌧️', label: '진눈깨비' },
+  61: { emoji: '🌧️', label: '비' },
+  63: { emoji: '🌧️', label: '비' },
+  65: { emoji: '🌧️', label: '폭우' },
+  66: { emoji: '🌧️', label: '빙우' },
+  67: { emoji: '🌧️', label: '빙우' },
+  71: { emoji: '❄️', label: '눈' },
+  73: { emoji: '❄️', label: '눈' },
+  75: { emoji: '❄️', label: '폭설' },
+  77: { emoji: '❄️', label: '눈' },
+  80: { emoji: '🌦️', label: '소나기' },
+  81: { emoji: '🌦️', label: '소나기' },
+  82: { emoji: '🌦️', label: '폭우' },
+  85: { emoji: '❄️', label: '눈' },
+  86: { emoji: '❄️', label: '폭설' },
+  95: { emoji: '🌩️', label: '뇌우' },
+  96: { emoji: '🌩️', label: '뇌우' },
+  99: { emoji: '🌩️', label: '뇌우' },
+};
+
+export interface WeatherInfo {
+  emoji: string;
+  label: string;
+  temperatureMax?: number;
+  temperatureMin?: number;
+}
+
+export function weatherCodeToInfo(code: number): { emoji: string; label: string } {
+  return WMO_CODE_MAP[code] ?? { emoji: '❓', label: '알 수 없음' };
+}
+
+const DEFAULT_LAT = 37.5665;
+const DEFAULT_LNG = 126.978;
+
+export async function fetchWeather(
+  date: string,
+  lat = DEFAULT_LAT,
+  lng = DEFAULT_LNG,
+): Promise<WeatherInfo | null> {
+  try {
+    const res = await fetch(
+      `https://archive-api.open-meteo.com/v1/archive?latitude=${lat}&longitude=${lng}&start_date=${date}&end_date=${date}&daily=weathercode,temperature_2m_max,temperature_2m_min&timezone=Asia/Seoul`,
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    const code = data.daily?.weathercode?.[0];
+    if (code == null) return null;
+    const info = weatherCodeToInfo(code);
+    return {
+      ...info,
+      temperatureMax: data.daily?.temperature_2m_max?.[0],
+      temperatureMin: data.daily?.temperature_2m_min?.[0],
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #265
- 백엔드: `notes` 테이블에 `drinkDate` (DATE, nullable) 컬럼 추가 + 멱등 마이그레이션
- DTO: `drinkDate` 필드 + `@Matches` YYYY-MM-DD 형식 검증
- 프론트: NewNote/EditNote에 음용 날짜 선택 DatePicker 추가
- NoteDetail에 음용 날짜 + Open-Meteo API 날씨 이모지/기온 표시
- 날씨 유틸: WMO 코드 → 한국어 이모지 매핑, 실패 시 graceful fallback

## Test plan
- [x] 프론트엔드 빌드 성공
- [x] 백엔드 빌드 성공
- [x] 백엔드 단위 테스트 23개 통과
- [ ] 프로덕션 마이그레이션 실행
- [ ] 차록 작성 시 날짜 선택 → 저장 → 상세에서 날씨 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)