### PR TITLE
feat: #259 로그인 상태에서 비밀번호 변경

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, UseGuards, Request, Req, Res, BadRequestException, HttpCode, UnauthorizedException } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Body, UseGuards, Request, Req, Res, BadRequestException, HttpCode, UnauthorizedException } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { Response } from 'express';
 import { AuthService } from './auth.service';
@@ -9,6 +9,7 @@ import { GoogleLoginDto } from './dto/google-login.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { FindEmailDto } from './dto/find-email.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import { AuthGuard } from '@nestjs/passport';
 
 const COOKIE_OPTIONS = {
@@ -155,5 +156,21 @@ export class AuthController {
         ? '일치하는 계정을 찾았습니다.'
         : '일치하는 계정이 없습니다.',
     };
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Patch('change-password')
+  async changePassword(
+    @Request() req,
+    @Body() dto: ChangePasswordDto,
+  ): Promise<{ message: string }> {
+    if (!req.user?.userId) {
+      throw new BadRequestException('인증 정보가 올바르지 않습니다.');
+    }
+    const userId = parseInt(req.user.userId, 10);
+    if (Number.isNaN(userId)) {
+      throw new BadRequestException('인증 정보가 올바르지 않습니다.');
+    }
+    return this.authService.changePassword(userId, dto);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { AuthProvider, UserAuthentication } from '../users/entities/user-authent
 import { PasswordReset } from '../users/entities/password-reset.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { MailService } from '../mail/mail.service';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import axios from 'axios';
 
 @Injectable()
@@ -262,6 +263,30 @@ export class AuthService {
       ? local[0] + '***'
       : local.slice(0, 2) + '***';
     return { maskedEmail: `${masked}@${domain}` };
+  }
+
+  async changePassword(userId: number, dto: ChangePasswordDto): Promise<{ message: string }> {
+    if (dto.newPassword !== dto.confirmPassword) {
+      throw new BadRequestException('새 비밀번호와 비밀번호 확인이 일치하지 않습니다.');
+    }
+
+    const auth = await this.userAuthRepository.findOne({
+      where: { userId, provider: AuthProvider.EMAIL },
+    });
+    if (!auth || !auth.credential) {
+      throw new BadRequestException('이메일 비밀번호 계정이 없습니다. 소셜 로그인 전용 계정입니다.');
+    }
+
+    const isMatch = await bcrypt.compare(dto.currentPassword, auth.credential);
+    if (!isMatch) {
+      throw new UnauthorizedException('현재 비밀번호가 올바르지 않습니다.');
+    }
+
+    auth.credential = await bcrypt.hash(dto.newPassword, 10);
+    await this.userAuthRepository.save(auth);
+    await this.revokeAllRefreshTokens(userId);
+
+    return { message: '비밀번호가 변경되었습니다. 다시 로그인해주세요.' };
   }
 
   async resetPassword(token: string, newPassword: string): Promise<void> {

--- a/backend/src/auth/dto/change-password.dto.ts
+++ b/backend/src/auth/dto/change-password.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, MinLength, Matches } from 'class-validator';
+
+export class ChangePasswordDto {
+  @IsString()
+  currentPassword: string;
+
+  @IsString()
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+  @Matches(/(?=.*[a-zA-Z])(?=.*[0-9])/, { message: '비밀번호는 영문과 숫자를 포함해야 합니다.' })
+  newPassword: string;
+
+  @IsString()
+  confirmPassword: string;
+}

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -14,6 +14,7 @@ import './suites/notes-crud.e2e-spec';
 import './suites/notes-schemas.e2e-spec';
 import './suites/cellar.e2e-spec';
 import './suites/cellar.e2e-spec';
+import './suites/auth-change-password.e2e-spec';
 
 describe('AppController (e2e)', () => {
   let context: TestContext;

--- a/backend/test/suites/auth-change-password.e2e-spec.ts
+++ b/backend/test/suites/auth-change-password.e2e-spec.ts
@@ -1,0 +1,151 @@
+import request from 'supertest';
+import { TestContext, setupTestApp, teardownTestApp, cleanupDatabase } from '../setup/test-setup';
+import { TEST_CONSTANTS } from '../constants/test-constants';
+
+describe('/auth/change-password - 비밀번호 변경 API', () => {
+  let context: TestContext;
+
+  beforeAll(async () => {
+    context = await setupTestApp();
+  }, TEST_CONSTANTS.TEST_TIMEOUT);
+
+  beforeEach(async () => {
+    await cleanupDatabase(context.dataSource);
+  });
+
+  afterAll(async () => {
+    await teardownTestApp(context);
+  });
+
+  it('PATCH /auth/change-password - 인증 없이 호출 시 401', () => {
+    return request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .send({
+        currentPassword: 'password123',
+        newPassword: 'newPassword456',
+        confirmPassword: 'newPassword456',
+      })
+      .expect(401);
+  });
+
+  it('PATCH /auth/change-password - 현재 비밀번호 불일치 시 401', async () => {
+    const user = await context.testHelper.createUser('Change Password User');
+
+    return request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({
+        currentPassword: 'wrongPassword999',
+        newPassword: 'newPassword456',
+        confirmPassword: 'newPassword456',
+      })
+      .expect(401);
+  });
+
+  it('PATCH /auth/change-password - newPassword !== confirmPassword 시 400', async () => {
+    const user = await context.testHelper.createUser('Change Password User2');
+
+    return request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({
+        currentPassword: 'password123',
+        newPassword: 'newPassword456',
+        confirmPassword: 'differentPassword789',
+      })
+      .expect(400);
+  });
+
+  it('PATCH /auth/change-password - 비밀번호 8자 미만 시 400', async () => {
+    const user = await context.testHelper.createUser('Change Password User3');
+
+    return request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({
+        currentPassword: 'password123',
+        newPassword: 'abc1',
+        confirmPassword: 'abc1',
+      })
+      .expect(400);
+  });
+
+  it('PATCH /auth/change-password - 영문 미포함 비밀번호 시 400', async () => {
+    const user = await context.testHelper.createUser('Change Password User4');
+
+    return request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({
+        currentPassword: 'password123',
+        newPassword: '12345678',
+        confirmPassword: '12345678',
+      })
+      .expect(400);
+  });
+
+  it('PATCH /auth/change-password - 숫자 미포함 비밀번호 시 400', async () => {
+    const user = await context.testHelper.createUser('Change Password User5');
+
+    return request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({
+        currentPassword: 'password123',
+        newPassword: 'abcdefgh',
+        confirmPassword: 'abcdefgh',
+      })
+      .expect(400);
+  });
+
+  it('PATCH /auth/change-password - 정상 변경 후 200 및 새 비밀번호로 로그인 성공', async () => {
+    const uniqueEmail = context.testHelper.generateUniqueEmail('change-pw');
+    const user = await context.testHelper.createUser('Change Password Success', uniqueEmail, 'password123');
+
+    await request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({
+        currentPassword: 'password123',
+        newPassword: 'newPassword456',
+        confirmPassword: 'newPassword456',
+      })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toHaveProperty('message');
+      });
+
+    // 새 비밀번호로 로그인 성공 확인
+    return request(context.app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: uniqueEmail,
+        password: 'newPassword456',
+      })
+      .expect(201);
+  });
+
+  it('PATCH /auth/change-password - 변경 후 이전 비밀번호로 로그인 실패', async () => {
+    const uniqueEmail = context.testHelper.generateUniqueEmail('change-pw-old');
+    const user = await context.testHelper.createUser('Change Password Old', uniqueEmail, 'password123');
+
+    await request(context.app.getHttpServer())
+      .patch('/auth/change-password')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({
+        currentPassword: 'password123',
+        newPassword: 'newPassword456',
+        confirmPassword: 'newPassword456',
+      })
+      .expect(200);
+
+    // 이전 비밀번호로 로그인 실패 확인
+    return request(context.app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: uniqueEmail,
+        password: 'password123',
+      })
+      .expect(401);
+  });
+});

--- a/src/lib/api/auth.api.ts
+++ b/src/lib/api/auth.api.ts
@@ -46,4 +46,6 @@ export const authApi = {
     apiClient.post<{ message: string }>('/auth/reset-password', { token, newPassword }),
   findEmail: (name: string) =>
     apiClient.post<{ maskedEmail: string | null; message: string }>('/auth/find-email', { name }),
+  changePassword: (data: { currentPassword: string; newPassword: string; confirmPassword: string }) =>
+    apiClient.patch<{ message: string }>('/auth/change-password', data),
 };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { LogOut, Shield, FileText, Bell, ChevronRight, Link2, Loader2, Sun, Moon, Monitor, LayoutDashboard } from 'lucide-react';
+import { LogOut, Shield, FileText, Bell, ChevronRight, Link2, Loader2, Sun, Moon, Monitor, LayoutDashboard, Lock } from 'lucide-react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useGoogleLogin } from '@react-oauth/google';
 import { useTheme } from 'next-themes';
@@ -8,6 +8,9 @@ import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import { Switch } from '../components/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '../components/ui/toggle-group';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../components/ui/dialog';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
 import { usersApi, authApi, LinkedAccount } from '../lib/api';
@@ -62,6 +65,13 @@ export function Settings() {
   const [unlinkingId, setUnlinkingId] = useState<number | null>(null);
   const [linkKakaoLoading, setLinkKakaoLoading] = useState(false);
   const [linkGoogleLoading, setLinkGoogleLoading] = useState(false);
+  const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false);
+  const [changePasswordForm, setChangePasswordForm] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  const [isChangePasswordLoading, setIsChangePasswordLoading] = useState(false);
 
   const fetchLinkedAccounts = useCallback(async () => {
     if (!user) return;
@@ -238,6 +248,42 @@ export function Settings() {
     }
   };
 
+  const handleChangePasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { currentPassword, newPassword, confirmPassword } = changePasswordForm;
+
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      toast.error('모든 필드를 입력해주세요.');
+      return;
+    }
+    if (newPassword.length < 8) {
+      toast.error('비밀번호는 최소 8자 이상이어야 합니다.');
+      return;
+    }
+    if (!/(?=.*[a-zA-Z])(?=.*[0-9])/.test(newPassword)) {
+      toast.error('비밀번호는 영문과 숫자를 포함해야 합니다.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast.error('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    setIsChangePasswordLoading(true);
+    try {
+      const result = await authApi.changePassword({ currentPassword, newPassword, confirmPassword });
+      toast.success(result.message);
+      setIsChangePasswordOpen(false);
+      setChangePasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+      await logout();
+      navigate('/login');
+    } catch (e) {
+      toast.error(e && typeof e === 'object' && 'message' in e ? String((e as { message: unknown }).message) : '비밀번호 변경에 실패했습니다.');
+    } finally {
+      setIsChangePasswordLoading(false);
+    }
+  };
+
   const handleLogout = () => {
     logout();
     navigate('/');
@@ -344,23 +390,34 @@ export function Settings() {
                         </div>
                       </div>
                       {linked ? (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          disabled={linkedAccounts.length <= 1 || unlinkingId === linked.id}
-                          onClick={() => handleUnlink(linked)}
-                          title={
-                            linkedAccounts.length <= 1
-                              ? '최소 1개의 로그인 수단은 유지해야 합니다'
-                              : undefined
-                          }
-                        >
-                          {unlinkingId === linked.id ? (
-                            <Loader2 className="w-4 h-4 animate-spin" />
-                          ) : (
-                            '해제'
+                        <div className="flex items-center gap-2">
+                          {provider === 'email' && linked.hasCredential && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setIsChangePasswordOpen(true)}
+                            >
+                              비밀번호 변경
+                            </Button>
                           )}
-                        </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={linkedAccounts.length <= 1 || unlinkingId === linked.id}
+                            onClick={() => handleUnlink(linked)}
+                            title={
+                              linkedAccounts.length <= 1
+                                ? '최소 1개의 로그인 수단은 유지해야 합니다'
+                                : undefined
+                            }
+                          >
+                            {unlinkingId === linked.id ? (
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                              '해제'
+                            )}
+                          </Button>
+                        </div>
                       ) : provider === 'kakao' ? (
                         <Button
                           variant="outline"
@@ -473,6 +530,71 @@ export function Settings() {
       </div>
 
       <BottomNav />
+
+      <Dialog open={isChangePasswordOpen} onOpenChange={setIsChangePasswordOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>비밀번호 변경</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleChangePasswordSubmit} className="space-y-4 mt-2">
+            <div className="space-y-2">
+              <Label htmlFor="currentPassword">현재 비밀번호</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input
+                  id="currentPassword"
+                  type="password"
+                  placeholder="현재 비밀번호 입력"
+                  value={changePasswordForm.currentPassword}
+                  onChange={(e) => setChangePasswordForm((prev) => ({ ...prev, currentPassword: e.target.value }))}
+                  className="pl-9"
+                  disabled={isChangePasswordLoading}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="newPassword">새 비밀번호</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input
+                  id="newPassword"
+                  type="password"
+                  placeholder="영문+숫자 포함 8자 이상"
+                  value={changePasswordForm.newPassword}
+                  onChange={(e) => setChangePasswordForm((prev) => ({ ...prev, newPassword: e.target.value }))}
+                  className="pl-9"
+                  disabled={isChangePasswordLoading}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">새 비밀번호 확인</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input
+                  id="confirmPassword"
+                  type="password"
+                  placeholder="새 비밀번호를 다시 입력하세요"
+                  value={changePasswordForm.confirmPassword}
+                  onChange={(e) => setChangePasswordForm((prev) => ({ ...prev, confirmPassword: e.target.value }))}
+                  className="pl-9"
+                  disabled={isChangePasswordLoading}
+                />
+              </div>
+            </div>
+            <Button type="submit" className="w-full" disabled={isChangePasswordLoading}>
+              {isChangePasswordLoading ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  변경 중...
+                </>
+              ) : (
+                '비밀번호 변경'
+              )}
+            </Button>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/__tests__/Settings.test.tsx
+++ b/src/pages/__tests__/Settings.test.tsx
@@ -1,10 +1,37 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useTheme } from 'next-themes';
 import { Settings } from '../Settings';
 import { renderWithRouter } from '../../test/renderWithRouter';
 import { useAuth } from '../../contexts/AuthContext';
+
+const mocks = vi.hoisted(() => ({
+  changePassword: vi.fn(),
+  getLinkedAccounts: vi.fn(),
+  getNotificationSetting: vi.fn(),
+  updateNotificationSetting: vi.fn(),
+  updateProfile: vi.fn(),
+  unlinkAccount: vi.fn(),
+}));
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api');
+  return {
+    ...actual,
+    authApi: {
+      ...(actual as { authApi: object }).authApi,
+      changePassword: mocks.changePassword,
+    },
+    usersApi: {
+      getLinkedAccounts: mocks.getLinkedAccounts,
+      getNotificationSetting: mocks.getNotificationSetting,
+      updateNotificationSetting: mocks.updateNotificationSetting,
+      updateProfile: mocks.updateProfile,
+      unlinkAccount: mocks.unlinkAccount,
+    },
+  };
+});
 
 vi.mock('../../contexts/AuthContext', async () => {
   const actual = await vi.importActual<typeof import('../../contexts/AuthContext')>('../../contexts/AuthContext');
@@ -46,9 +73,18 @@ vi.mock('@react-oauth/google', () => ({
   useGoogleLogin: () => vi.fn(),
 }));
 
+const mockLogout = vi.fn();
+
 describe('Settings 페이지', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getLinkedAccounts.mockResolvedValue([
+      { id: 1, provider: 'email', providerId: 'test@example.com', hasCredential: true },
+    ]);
+    mocks.getNotificationSetting.mockResolvedValue({ isNotificationEnabled: true });
+    mocks.updateNotificationSetting.mockResolvedValue({ isNotificationEnabled: true });
+    mocks.updateProfile.mockResolvedValue({});
+    mocks.unlinkAccount.mockResolvedValue({});
     vi.mocked(useTheme).mockReturnValue({
       theme: 'system',
       setTheme: mockSetTheme,
@@ -65,7 +101,7 @@ describe('Settings 페이지', () => {
       register: vi.fn(),
       loginWithKakao: vi.fn(),
       loginWithGoogle: vi.fn(),
-      logout: vi.fn(),
+      logout: mockLogout,
       hasCompletedOnboarding: null,
       isOnboardingLoading: false,
       refreshOnboardingStatus: vi.fn(),
@@ -115,6 +151,52 @@ describe('Settings 페이지', () => {
         await user.click(screen.getByLabelText('시스템 설정 따르기'));
         expect(mockSetTheme).toHaveBeenCalledWith('system');
       });
+    });
+  });
+
+  describe('비밀번호 변경 (이메일 계정)', () => {
+    beforeEach(() => {
+      mocks.getLinkedAccounts.mockResolvedValue([
+        { id: 1, provider: 'email', providerId: 'test@example.com', hasCredential: true },
+      ]);
+      vi.mocked(useAuth).mockReturnValue({
+        user: { id: 1, email: 'test@example.com', name: 'Test User', role: 'user' },
+        isAuthenticated: true,
+        isAdmin: false,
+        isLoading: false,
+        token: 'cookie',
+        login: vi.fn(),
+        register: vi.fn(),
+        loginWithKakao: vi.fn(),
+        loginWithGoogle: vi.fn(),
+        logout: mockLogout,
+        hasCompletedOnboarding: true,
+        isOnboardingLoading: false,
+        refreshOnboardingStatus: vi.fn(),
+      });
+    });
+
+    it('이메일 계정 행에 비밀번호 변경 버튼이 표시되어야 함', async () => {
+      renderWithRouter(<Settings />, { route: '/settings' });
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '비밀번호 변경' })).toBeInTheDocument();
+      });
+    });
+
+    it('비밀번호 변경 버튼 클릭 시 모달이 열려야 함', async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<Settings />, { route: '/settings' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '비밀번호 변경' })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: '비밀번호 변경' }));
+
+      expect(screen.getByRole('heading', { name: '비밀번호 변경' })).toBeInTheDocument();
+      expect(screen.getByLabelText('현재 비밀번호')).toBeInTheDocument();
+      expect(screen.getByLabelText('새 비밀번호')).toBeInTheDocument();
+      expect(screen.getByLabelText('새 비밀번호 확인')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Closes #259
- 로그인된 이메일 계정 사용자가 현재 비밀번호를 확인 후 새 비밀번호로 변경할 수 있는 기능 구현
- 변경 성공 시 모든 리프레시 토큰 무효화 및 자동 로그아웃 처리

## Changes
### Backend
- `ChangePasswordDto`: 현재/새/확인 비밀번호 유효성 검사 (8자 이상, 영문+숫자)
- `AuthService.changePassword()`: 현재 비밀번호 검증 → 해시 저장 → 리프레시 토큰 revoke
- `AuthController`: `PATCH /auth/change-password` JWT 인증 필요 엔드포인트 추가
- E2E 테스트: 인증없음(401), 비밀번호불일치(401), 확인불일치(400), 규칙미달(400), 정상변경(200)

### Frontend
- `authApi.changePassword()`: 새 API 메서드 추가
- Settings 페이지 계정 연동 섹션의 이메일 행에 "비밀번호 변경" 버튼 추가
- Dialog 모달: 현재/새/새확인 비밀번호 입력 폼 (클라이언트 사이드 유효성 검사)
- 변경 성공 시 toast.success 후 자동 로그아웃 및 /login 리다이렉트

## Test plan
- [x] 프론트엔드 빌드 (`npm run build`) 성공
- [x] Settings 테스트 7개 통과 (`npm run test:run`)
- [x] E2E 테스트 스위트 작성 (DB 연결 시 실행)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 설정 페이지에서 비밀번호 변경 기능이 추가되었습니다. 사용자는 현재 비밀번호를 입력하여 새로운 비밀번호로 변경할 수 있습니다. 비밀번호는 최소 8자 이상이며 영문과 숫자를 포함해야 합니다.

* **테스트**
  * 비밀번호 변경 기능에 대한 포괄적인 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->