### PR TITLE
fix: 다회모드/블라인드 세션 완료 시 모드 OFF 처리

### DIFF
--- a/src/pages/BlindSessionDetail.tsx
+++ b/src/pages/BlindSessionDetail.tsx
@@ -6,6 +6,7 @@ import { Button } from '../components/ui/button';
 import { blindSessionsApi } from '../lib/api';
 import { toast } from 'sonner';
 import { useAuth } from '../contexts/AuthContext';
+import { useAppMode } from '../contexts/AppModeContext';
 import { logger } from '../lib/logger';
 
 type SessionData = {
@@ -28,6 +29,7 @@ export function BlindSessionDetail() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const { isAuthenticated, user } = useAuth();
+  const { clearBlind } = useAppMode();
   const [session, setSession] = useState<SessionData | null>(null);
   const [loading, setLoading] = useState(true);
   const [ending, setEnding] = useState(false);
@@ -62,6 +64,7 @@ export function BlindSessionDetail() {
     try {
       setEnding(true);
       await blindSessionsApi.endSession(parseInt(id, 10));
+      clearBlind();
       toast.success('세션이 종료되었습니다.');
       setSession((prev) => (prev ? { ...prev, status: 'ended' } : null));
     } catch (err) {
@@ -102,6 +105,12 @@ export function BlindSessionDetail() {
   const hasWrittenCurrentRound =
     session?.currentRoundId != null &&
     (currentUserParticipant?.completedRounds ?? []).includes(session.currentRoundId);
+
+  useEffect(() => {
+    if (session?.status === 'ended') {
+      clearBlind();
+    }
+  }, [session?.status, clearBlind]);
 
   if (loading || !session) {
     return (

--- a/src/pages/SessionInProgress.tsx
+++ b/src/pages/SessionInProgress.tsx
@@ -8,6 +8,7 @@ import { Label } from '../components/ui/label';
 import { teaSessionsApi } from '../lib/api';
 import { TeaSession, TeaSessionSteep } from '../types';
 import { toast } from 'sonner';
+import { useAppMode } from '../contexts/AppModeContext';
 import { logger } from '../lib/logger';
 
 const AROMA_OPTIONS = [
@@ -23,6 +24,7 @@ const BODY_FEELING_OPTIONS = [
 export function SessionInProgress() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { clearSession } = useAppMode();
   const sessionId = id ? parseInt(id, 10) : NaN;
 
   const [session, setSession] = useState<TeaSession | null>(null);
@@ -137,6 +139,12 @@ export function SessionInProgress() {
   const sortedSteeps = [...steeps].sort(
     (a, b) => (a.steepNumber ?? 0) - (b.steepNumber ?? 0)
   );
+
+  useEffect(() => {
+    if (session?.noteId) {
+      clearSession();
+    }
+  }, [session?.noteId, clearSession]);
 
   if (loading || !session) {
     return (

--- a/src/pages/SessionSummary.tsx
+++ b/src/pages/SessionSummary.tsx
@@ -14,6 +14,7 @@ import { teaSessionsApi, notesApi } from '../lib/api';
 import { TeaSession, TeaSessionSteep, RatingSchema, RatingAxis } from '../types';
 import { toast } from 'sonner';
 import { useAuth } from '../contexts/AuthContext';
+import { useAppMode } from '../contexts/AppModeContext';
 import { logger } from '../lib/logger';
 import { RATING_DEFAULT, RATING_MIN, RATING_MAX, NAVIGATION_DELAY } from '../constants';
 
@@ -21,6 +22,7 @@ export function SessionSummary() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
+  const { clearSession } = useAppMode();
   const sessionId = id ? parseInt(id, 10) : NaN;
 
   const [session, setSession] = useState<TeaSession | null>(null);
@@ -142,6 +144,7 @@ export function SessionSummary() {
         isPublic,
       });
 
+      clearSession();
       toast.success('노트로 발행되었습니다.');
       setTimeout(() => navigate(`/note/${noteId}`), NAVIGATION_DELAY);
     } catch (error) {


### PR DESCRIPTION
## Summary
- 세션 완료 후에도 ModeCarousel에서 ON 상태가 유지되는 버그 수정
- SessionSummary: 노트 발행 성공 시 clearSession() 호출
- BlindSessionDetail: 세션 종료 시 clearBlind() 호출
- SessionInProgress/BlindSessionDetail: 이미 완료된 세션 방문 시에도 clear 호출

## Test plan
- [x] npm run build
- [x] 로컬 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 블라인드 세션 종료 시 앱 상태가 자동으로 초기화되어 상태 충돌 방지
  * 노트 발행 시 이전 세션 상태가 자동으로 정리됨
  * 세션 발행 완료 후 상태 정리 개선으로 전반적인 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->