### PR TITLE
fix: stabilize login persistence and production auth flow

### DIFF
--- a/api/__tests__/proxy.test.ts
+++ b/api/__tests__/proxy.test.ts
@@ -63,13 +63,13 @@ describe('Vercel Proxy', () => {
       globalThis.fetch = fetchMock;
 
       const req = createMockReq({
-        headers: { origin: 'https://cha-log-gilt.vercel.app' },
+        headers: { origin: 'https://www.chamung.com' },
       });
       const res = createMockRes();
 
       await handler(req, res);
 
-      expect(res._headers['access-control-allow-origin']).toBe('https://cha-log-gilt.vercel.app');
+      expect(res._headers['access-control-allow-origin']).toBe('https://www.chamung.com');
       expect(res._headers['access-control-allow-credentials']).toBe('true');
       expect(res._headers['vary']).toBe('Origin');
     });
@@ -129,7 +129,7 @@ describe('Vercel Proxy', () => {
     it('OPTIONS preflight에 200을 응답해야 한다', async () => {
       const req = createMockReq({
         method: 'OPTIONS',
-        headers: { origin: 'https://cha-log-gilt.vercel.app' },
+        headers: { origin: 'https://www.chamung.com' },
       });
       const res = createMockRes();
 

--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -21,7 +21,7 @@ function getAllowedOrigin(req: any): string | null {
   const origin = req.headers?.origin;
   if (!origin) return null;
   const allowed = [
-    'https://cha-log-gilt.vercel.app',
+    'https://www.chamung.com',
     process.env.FRONTEND_URL,
     ...(process.env.FRONTEND_URLS?.split(',').map(u => u.trim()) ?? []),
   ].filter(Boolean);

--- a/backend/scripts/setup-test-env.js
+++ b/backend/scripts/setup-test-env.js
@@ -10,51 +10,48 @@ const path = require('path');
 const fs = require('fs');
 
 const envPath = path.join(__dirname, '../.env');
+const envTestPath = path.join(__dirname, '../.env.test');
 const envExamplePath = path.join(__dirname, '../.env.example');
 
-// .env 파일 존재 여부 확인
-if (!fs.existsSync(envPath)) {
-  console.error('❌ backend/.env 파일을 찾을 수 없습니다.');
-  
-  // .env.example이 있으면 복사 제안
-  if (fs.existsSync(envExamplePath)) {
-    console.error(`   다음 명령어를 실행하세요:`);
-    console.error(`   cp backend/.env.example backend/.env`);
-    console.error(`   그 후 DATABASE_URL을 설정해주세요.`);
+if (fs.existsSync(envPath)) {
+  config({ path: envPath });
+}
+
+if (fs.existsSync(envTestPath)) {
+  config({ path: envTestPath, override: true });
+}
+
+const configuredTestDatabaseUrl = process.env.TEST_DATABASE_URL;
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!configuredTestDatabaseUrl && !databaseUrl) {
+  console.error('❌ TEST_DATABASE_URL 또는 DATABASE_URL이 설정되지 않았습니다.');
+
+  if (!fs.existsSync(envPath) && fs.existsSync(envExamplePath)) {
+    console.error('   다음 명령어를 실행하세요:');
+    console.error('   cp backend/.env.example backend/.env');
+    console.error('   그 후 DATABASE_URL 또는 TEST_DATABASE_URL을 설정해주세요.');
   } else {
-    console.error('   backend/.env 파일을 생성하고 DATABASE_URL을 설정해주세요.');
+    console.error('   backend/.env 또는 backend/.env.test에 TEST_DATABASE_URL을 설정해주세요.');
   }
   process.exit(1);
 }
 
-// .env 파일 로드
-config({ path: envPath });
-
-const databaseUrl = process.env.DATABASE_URL;
-
-if (!databaseUrl) {
-  console.error('❌ DATABASE_URL이 설정되지 않았습니다.');
-  console.error('   backend/.env 파일에 DATABASE_URL을 설정해주세요.');
-  process.exit(1);
-}
-
 try {
-  const url = new URL(databaseUrl);
-  
-  // 데이터베이스 이름에 _test 추가
-  const dbName = url.pathname.slice(1); // 첫 번째 '/' 제거
-  const testDbName = dbName.includes('_test') ? dbName : `${dbName}_test`;
-  url.pathname = `/${testDbName}`;
-  
-  const testDatabaseUrl = url.toString();
-  
-  // 환경 변수 설정
+  const testDatabaseUrl = configuredTestDatabaseUrl
+    ? configuredTestDatabaseUrl
+    : (() => {
+        const url = new URL(databaseUrl);
+        const dbName = url.pathname.slice(1);
+        const testDbName = dbName.includes('_test') ? dbName : `${dbName}_test`;
+        url.pathname = `/${testDbName}`;
+        return url.toString();
+      })();
+
   process.env.TEST_DATABASE_URL = testDatabaseUrl;
   process.env.NODE_ENV = 'test';
-  
-  console.log(`✅ TEST_DATABASE_URL이 자동으로 설정되었습니다:`);
-  console.log(`   ${testDatabaseUrl}`);
-  
+
+
   // Jest 실행
   const { spawn } = require('child_process');
   const jestArgs = process.argv.slice(2); // 추가 인자 전달 (예: --testPathPatterns)

--- a/backend/scripts/start-ssh-tunnel.sh
+++ b/backend/scripts/start-ssh-tunnel.sh
@@ -19,6 +19,17 @@ EC2_USER=${EC2_USER:-}
 SSH_TUNNEL_LOCAL_PORT=${SSH_TUNNEL_LOCAL_PORT:-3307}
 SSH_TUNNEL_REMOTE_HOST=${SSH_TUNNEL_REMOTE_HOST:-}
 SSH_TUNNEL_REMOTE_PORT=${SSH_TUNNEL_REMOTE_PORT:-3306}
+DATABASE_URL=${DATABASE_URL:-}
+
+# SSH_TUNNEL_REMOTE_HOST가 비어 있으면 DATABASE_URL에서 자동 추출
+if [ -z "$SSH_TUNNEL_REMOTE_HOST" ] && [ -n "$DATABASE_URL" ]; then
+    SSH_TUNNEL_REMOTE_HOST=$(node -e "const url = new URL(process.env.DATABASE_URL); console.log(url.hostname || '')")
+fi
+
+# SSH_TUNNEL_REMOTE_PORT가 비어 있으면 DATABASE_URL에서 자동 추출
+if [ -z "$SSH_TUNNEL_REMOTE_PORT" ] && [ -n "$DATABASE_URL" ]; then
+    SSH_TUNNEL_REMOTE_PORT=$(node -e "const url = new URL(process.env.DATABASE_URL); console.log(url.port || '3306')")
+fi
 
 # 필수 환경 변수 확인
 if [ -z "$SSH_KEY_PATH" ] || [ -z "$EC2_HOST" ] || [ -z "$EC2_USER" ] || [ -z "$SSH_TUNNEL_REMOTE_HOST" ]; then
@@ -28,7 +39,7 @@ if [ -z "$SSH_KEY_PATH" ] || [ -z "$EC2_HOST" ] || [ -z "$EC2_USER" ] || [ -z "$
     echo "  - SSH_KEY_PATH"
     echo "  - EC2_HOST (Lightsail Public IP)"
     echo "  - EC2_USER (Lightsail SSH 사용자명)"
-    echo "  - SSH_TUNNEL_REMOTE_HOST"
+    echo "  - SSH_TUNNEL_REMOTE_HOST (or DATABASE_URL)"
     exit 1
 fi
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,7 +28,7 @@ import { Tag } from './notes/entities/tag.entity';
 import { UsersService } from './users/users.service';
 import { UserRole } from './users/entities/user.entity';
 
-const AdminJSModulePromise = (async () => {
+const createAdminJsModule = async () => {
   const AdminJSTypeorm = await import('@adminjs/typeorm');
   const AdminJS = (await import('adminjs')).default;
   AdminJS.registerAdapter({
@@ -70,7 +70,9 @@ const AdminJSModulePromise = (async () => {
     },
     inject: [ConfigService, UsersService],
   });
-})();
+};
+
+const adminJsImports = process.env.NODE_ENV === 'test' ? [] : [createAdminJsModule()];
 
 @Module({
   imports: [
@@ -116,7 +118,7 @@ const AdminJSModulePromise = (async () => {
     AdminModule,
     TeaSessionsModule,
     BlindTastingModule,
-    AdminJSModulePromise,
+    ...adminJsImports,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,94 @@
+import { Response } from 'express';
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  const mockAuthService = {
+    register: jest.fn(),
+    login: jest.fn(),
+    loginWithKakao: jest.fn(),
+    loginWithGoogle: jest.fn(),
+    validateAndRotateRefreshToken: jest.fn(),
+    revokeAllRefreshTokens: jest.fn(),
+    getMe: jest.fn(),
+    linkKakao: jest.fn(),
+    linkGoogle: jest.fn(),
+    forgotPassword: jest.fn(),
+    resetPassword: jest.fn(),
+    findEmail: jest.fn(),
+    changePassword: jest.fn(),
+    verifyEmail: jest.fn(),
+    resendVerification: jest.fn(),
+    requestEmailChange: jest.fn(),
+    confirmEmailChange: jest.fn(),
+    withdraw: jest.fn(),
+  };
+
+  let controller: AuthController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new AuthController(mockAuthService as never);
+  });
+
+  it('login은 refresh_token 쿠키를 30일로 설정해야 한다', async () => {
+    const req = { user: { id: 1 } };
+    const res = {
+      cookie: jest.fn(),
+    } as unknown as Response;
+
+    mockAuthService.login.mockResolvedValue({
+      access_token: 'access',
+      refresh_token: 'refresh',
+      user: { id: 1, email: 'test@example.com', name: 'User' },
+    });
+
+    await controller.login(req as never, {} as never, res);
+
+    expect(mockAuthService.login).toHaveBeenCalledWith(req.user);
+    expect((res.cookie as jest.Mock).mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          'refresh_token',
+          'refresh',
+          expect.objectContaining({
+            httpOnly: true,
+            path: '/',
+            maxAge: 30 * 24 * 60 * 60 * 1000,
+          }),
+        ],
+      ]),
+    );
+  });
+
+  it('refresh는 refresh_token 쿠키를 30일로 다시 설정해야 한다', async () => {
+    const req = {
+      cookies: { refresh_token: 'old-refresh' },
+    };
+    const res = {
+      cookie: jest.fn(),
+    } as unknown as Response;
+
+    mockAuthService.validateAndRotateRefreshToken.mockResolvedValue({
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      userId: 1,
+    });
+
+    await controller.refresh(req as never, res);
+
+    expect(mockAuthService.validateAndRotateRefreshToken).toHaveBeenCalledWith('old-refresh');
+    expect((res.cookie as jest.Mock).mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          'refresh_token',
+          'new-refresh',
+          expect.objectContaining({
+            httpOnly: true,
+            path: '/',
+            maxAge: 30 * 24 * 60 * 60 * 1000,
+          }),
+        ],
+      ]),
+    );
+  });
+});

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -35,7 +35,7 @@ export class AuthController {
       registerDto.password,
     );
     res.cookie('access_token', result.access_token, { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 1000 });
-    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 7 * 24 * 60 * 60 * 1000 });
+    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 30 * 24 * 60 * 60 * 1000 });
     return result;
   }
 
@@ -45,7 +45,7 @@ export class AuthController {
   async login(@Request() req, @Body() loginDto: LoginDto, @Res({ passthrough: true }) res: Response) {
     const result = await this.authService.login(req.user);
     res.cookie('access_token', result.access_token, { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 1000 });
-    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 7 * 24 * 60 * 60 * 1000 });
+    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 30 * 24 * 60 * 60 * 1000 });
     return result;
   }
 
@@ -54,7 +54,7 @@ export class AuthController {
   async loginWithKakao(@Body() kakaoLoginDto: KakaoLoginDto, @Res({ passthrough: true }) res: Response) {
     const result = await this.authService.loginWithKakao(kakaoLoginDto.accessToken);
     res.cookie('access_token', result.access_token, { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 1000 });
-    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 7 * 24 * 60 * 60 * 1000 });
+    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 30 * 24 * 60 * 60 * 1000 });
     return result;
   }
 
@@ -63,7 +63,7 @@ export class AuthController {
   async loginWithGoogle(@Body() googleLoginDto: GoogleLoginDto, @Res({ passthrough: true }) res: Response) {
     const result = await this.authService.loginWithGoogle(googleLoginDto.accessToken);
     res.cookie('access_token', result.access_token, { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 1000 });
-    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 7 * 24 * 60 * 60 * 1000 });
+    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 30 * 24 * 60 * 60 * 1000 });
     return result;
   }
 
@@ -74,7 +74,7 @@ export class AuthController {
     if (!rawToken) throw new UnauthorizedException('리프레시 토큰이 없습니다.');
     const result = await this.authService.validateAndRotateRefreshToken(rawToken);
     res.cookie('access_token', result.access_token, { ...COOKIE_OPTIONS, maxAge: 60 * 60 * 1000 });
-    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 7 * 24 * 60 * 60 * 1000 });
+    res.cookie('refresh_token', result.refresh_token, { ...COOKIE_OPTIONS, maxAge: 30 * 24 * 60 * 60 * 1000 });
     return { message: '토큰이 갱신되었습니다.' };
   }
 

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -11,6 +11,7 @@ import { UserAuthentication } from '../users/entities/user-authentication.entity
 import { PasswordReset } from '../users/entities/password-reset.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { EmailVerificationToken } from './entities/email-verification-token.entity';
+import { EmailChangeToken } from './entities/email-change-token.entity';
 import { MailService } from '../mail/mail.service';
 import axios from 'axios';
 
@@ -76,6 +77,7 @@ describe('AuthService', () => {
   const mockMailService = {
     sendPasswordResetEmail: jest.fn(),
     sendVerificationEmail: jest.fn(),
+    sendEmailChangeEmail: jest.fn(),
   };
 
   const mockDataSource = {
@@ -117,6 +119,10 @@ describe('AuthService', () => {
         },
         {
           provide: getRepositoryToken(EmailVerificationToken),
+          useValue: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(EmailChangeToken),
           useValue: mockRepository,
         },
         {
@@ -297,6 +303,33 @@ describe('AuthService', () => {
 
       await expect(service.loginWithKakao('invalid_token')).rejects.toThrow(
         UnauthorizedException,
+      );
+    });
+  });
+
+  describe('refresh token lifetime', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-05-14T00:00:00.000Z'));
+      mockUsersService.getUserEmail.mockResolvedValue('test@example.com');
+      mockJwtService.sign.mockReturnValue('mock_jwt_token');
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('로그인 시 refresh token 만료일을 30일 뒤로 저장해야 함', async () => {
+      const user = createMockUser();
+
+      await service.login(user);
+
+      expect(mockRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: user.id,
+          isRevoked: false,
+          expiresAt: new Date('2026-06-13T00:00:00.000Z'),
+        }),
       );
     });
   });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -81,7 +81,7 @@ export class AuthService {
   private async generateRefreshTokenValue(userId: number): Promise<string> {
     const raw = randomBytes(32).toString('hex');
     const tokenHash = createHash('sha256').update(raw).digest('hex');
-    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7일
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30일
     await this.refreshTokenRepository.save({ userId, tokenHash, expiresAt, isRevoked: false });
     return raw;
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -23,7 +23,7 @@ async function bootstrap() {
   const allowedOrigins = [
     'http://localhost:5173',
     'http://localhost:3000',
-    'https://cha-log-gilt.vercel.app',
+    'https://www.chamung.com',
   ];
   
   // 환경 변수에서 추가 origin 가져오기

--- a/backend/test/setup/test-setup.ts
+++ b/backend/test/setup/test-setup.ts
@@ -35,8 +35,7 @@ export async function setupTestApp(): Promise<TestContext> {
   try {
     const url = new URL(testDbUrl);
     testDatabaseName = url.pathname.slice(1);
-    console.log(`[TEST] Using test database: ${testDatabaseName}`);
-    
+
     // 프로덕션 DB 사용 방지: DB 이름에 "test"가 없으면 에러 발생
     if (!testDatabaseName.includes('test') && !testDatabaseName.includes('_test')) {
       throw new Error(
@@ -90,11 +89,13 @@ export async function setupTestApp(): Promise<TestContext> {
 /**
  * 테스트 앱 종료
  */
-export async function teardownTestApp(context: TestContext): Promise<void> {
+export async function teardownTestApp(context?: TestContext): Promise<void> {
+  if (!context) {
+    return;
+  }
+
   try {
-    console.log(`[TEST] Cleaning up test database: ${context.testDatabaseName}`);
     await cleanupDatabase(context.dataSource);
-    console.log(`[TEST] Test database cleaned up: ${context.testDatabaseName}`);
   } catch (error) {
     console.error('[ERROR] Failed to clean up test database:', error);
   } finally {

--- a/backend/test/suites/auth-refresh.e2e-spec.ts
+++ b/backend/test/suites/auth-refresh.e2e-spec.ts
@@ -39,6 +39,22 @@ describe('/auth - Refresh Token & Cookie 인증', () => {
     expect(cookieStr).toContain('HttpOnly');
   });
 
+  it('POST /auth/login - refresh_token 쿠키는 30일 유지되어야 한다', async () => {
+    const email = `refresh-cookie-${Date.now()}@example.com`;
+    await registerUser(email);
+
+    const res = await request(context.app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'Password123!' })
+      .expect(201);
+
+    const cookies: string[] = res.headers['set-cookie'] as unknown as string[];
+    const refreshCookie = cookies.find((cookie) => cookie.startsWith('refresh_token='));
+
+    expect(refreshCookie).toBeDefined();
+    expect(refreshCookie).toContain('Max-Age=2592000');
+  });
+
   it('POST /auth/refresh - 유효한 refresh_token으로 토큰 갱신 성공', async () => {
     const email = `refresh-${Date.now()}@example.com`;
     const registerRes = await registerUser(email);

--- a/src/components/SpeedDialFAB.tsx
+++ b/src/components/SpeedDialFAB.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Plus, Leaf, PenLine, Package, RefreshCw, Eye, EyeOff, Store, ClipboardList, Tag } from 'lucide-react';
 import { cn } from './ui/utils';
 import { useAppMode } from '../contexts/AppModeContext';
+import { prepareKeyboard } from '../hooks/useMobileKeyboard';
 
 type MenuItem = {
   label: string;
@@ -55,8 +56,13 @@ export function SpeedDialFAB() {
 
   if (shouldHide) return null;
 
+  const FOCUS_PAGES = ['/note/new', '/cellar/new', '/teahouse/new', '/tags', '/tea/new'];
+
   const navigateTo = (path: string) => {
     setIsOpen(false);
+    if (FOCUS_PAGES.some((p) => path.startsWith(p))) {
+      prepareKeyboard();
+    }
     navigate(path);
   };
 

--- a/src/hooks/useAutoFocus.ts
+++ b/src/hooks/useAutoFocus.ts
@@ -1,13 +1,13 @@
 import { useEffect, useRef, type RefObject } from 'react';
+import { hasKeyboardProxy, transferFocus } from './useMobileKeyboard';
 
 /**
  * Mobile-compatible autofocus hook.
  *
- * On mobile browsers, programmatic `focus()` only opens the virtual keyboard
- * when called during a user-gesture or within the first animation frame after
- * navigation.  A short `requestAnimationFrame` + `setTimeout` combo gives the
- * browser enough time to finish layout while staying inside the "user
- * activation" window that iOS/Android require.
+ * If a keyboard proxy is active (created by `navigateWithKeyboard`),
+ * transfers focus from the proxy to the real input — keeping the iOS
+ * keyboard open.  Otherwise falls back to `requestAnimationFrame` +
+ * `setTimeout` which works on Desktop and Android.
  *
  * @param enabled - Whether to auto-focus (e.g. `!preselectedTeaId`)
  * @param deps   - Extra deps that should re-trigger the focus (default `[]`)
@@ -22,9 +22,13 @@ export function useAutoFocus<T extends HTMLElement = HTMLInputElement>(
   useEffect(() => {
     if (!enabled) return;
 
-    // requestAnimationFrame ensures the DOM is painted, then a minimal
-    // setTimeout pushes us past iOS's keyboard-suppression heuristic while
-    // keeping the delay imperceptible (~16-50 ms total).
+    // Path A: proxy input exists → transfer focus immediately (iOS keyboard stays open)
+    if (hasKeyboardProxy() && ref.current) {
+      transferFocus(ref.current);
+      return;
+    }
+
+    // Path B: no proxy → Desktop/Android fallback
     let raf: number;
     let timer: ReturnType<typeof setTimeout>;
 

--- a/src/hooks/useMobileKeyboard.ts
+++ b/src/hooks/useMobileKeyboard.ts
@@ -1,0 +1,51 @@
+const PROXY_ATTR = 'data-keyboard-proxy';
+const PROXY_TTL = 3000;
+
+/**
+ * Create an invisible proxy input and focus it synchronously.
+ * MUST be called inside a user-gesture (click/tap) handler so that
+ * iOS Safari opens the virtual keyboard.
+ *
+ * Returns a cleanup function that removes the proxy from the DOM.
+ */
+export function prepareKeyboard(): () => void {
+  // Remove any stale proxy
+  document.querySelector(`[${PROXY_ATTR}]`)?.remove();
+
+  const proxy = document.createElement('input');
+  proxy.setAttribute('type', 'text');
+  proxy.setAttribute('aria-hidden', 'true');
+  proxy.setAttribute('readonly', 'true');
+  proxy.setAttribute('tabindex', '-1');
+  proxy.setAttribute(PROXY_ATTR, 'true');
+  proxy.style.cssText =
+    'position:fixed;top:0;left:0;opacity:0;height:0;width:0;border:none;padding:0;font-size:16px;pointer-events:none;';
+
+  document.body.prepend(proxy);
+  proxy.focus();
+
+  // Safety net: auto-remove after TTL
+  const timer = setTimeout(() => proxy.remove(), PROXY_TTL);
+
+  return () => {
+    clearTimeout(timer);
+    proxy.remove();
+  };
+}
+
+/**
+ * Transfer focus from the proxy input to the real target.
+ * Because focus moves input→input, iOS keeps the keyboard open.
+ */
+export function transferFocus(target: HTMLElement): void {
+  const proxy = document.querySelector(`[${PROXY_ATTR}]`);
+  target.focus();
+  proxy?.remove();
+}
+
+/**
+ * Check whether a keyboard proxy is currently active in the DOM.
+ */
+export function hasKeyboardProxy(): boolean {
+  return document.querySelector(`[${PROXY_ATTR}]`) !== null;
+}

--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -103,12 +103,17 @@ describe('ApiClient', () => {
       window.removeEventListener('auth:logout', logoutHandler);
     });
 
-    it('/auth/ 엔드포인트에서는 토큰 갱신을 시도하지 않아야 한다', async () => {
-      fetchSpy.mockResolvedValueOnce(mockResponse(401, { message: 'Invalid credentials' }));
+    it('앱 시작 시 /auth/me가 401이면 토큰 갱신 후 다시 시도해야 한다', async () => {
+      fetchSpy.mockResolvedValueOnce(mockResponse(401, { message: 'Unauthorized' }));
+      fetchSpy.mockResolvedValueOnce(mockResponse(200, { message: '토큰이 갱신되었습니다.' }));
+      fetchSpy.mockResolvedValueOnce(mockResponse(200, { user: { id: 1, email: 'user@example.com', name: 'User' } }));
 
-      await expect(apiClient.get('/auth/me')).rejects.toMatchObject({ statusCode: 401 });
-      // refresh 호출 없이 1회만 호출
-      expect(fetchSpy).toHaveBeenCalledOnce();
+      const result = await apiClient.get<{ user: { id: number; email: string; name: string } }>('/auth/me');
+
+      expect(result).toEqual({ user: { id: 1, email: 'user@example.com', name: 'User' } });
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(fetchSpy.mock.calls[1][0]).toContain('/auth/refresh');
+      expect(fetchSpy.mock.calls[2][0]).toContain('/auth/me');
     });
 
     it('동시 401 요청 시 토큰 갱신은 1회만 수행해야 한다', async () => {

--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -116,6 +116,19 @@ describe('ApiClient', () => {
       expect(fetchSpy.mock.calls[2][0]).toContain('/auth/me');
     });
 
+    it('쿼리나 trailing slash가 붙은 /auth/me도 토큰 갱신 후 다시 시도해야 한다', async () => {
+      fetchSpy.mockResolvedValueOnce(mockResponse(401, { message: 'Unauthorized' }));
+      fetchSpy.mockResolvedValueOnce(mockResponse(200, { message: '토큰이 갱신되었습니다.' }));
+      fetchSpy.mockResolvedValueOnce(mockResponse(200, { user: { id: 1, email: 'user@example.com', name: 'User' } }));
+
+      const result = await apiClient.get<{ user: { id: number; email: string; name: string } }>('/auth/me/?source=boot');
+
+      expect(result).toEqual({ user: { id: 1, email: 'user@example.com', name: 'User' } });
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(fetchSpy.mock.calls[1][0]).toContain('/auth/refresh');
+      expect(fetchSpy.mock.calls[2][0]).toContain('/auth/me/?source=boot');
+    });
+
     it('동시 401 요청 시 토큰 갱신은 1회만 수행해야 한다', async () => {
       // Suppress auth:logout from reaching other listeners
       const suppressLogout = (e: Event) => e.stopImmediatePropagation();

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -566,8 +566,8 @@ class ApiClient {
           continue;
         }
 
-        // 401 시 토큰 갱신 후 1회 재시도 (인증 엔드포인트 제외)
-        if (response.status === 401 && !authRetried && !endpoint.startsWith('/auth/')) {
+        // 401 시 토큰 갱신 후 1회 재시도 (/auth/me 포함, 그 외 인증 엔드포인트 제외)
+        if (response.status === 401 && !authRetried && (!endpoint.startsWith('/auth/') || endpoint === '/auth/me')) {
           logger.info(`[API Request ${requestId}] 401 → 토큰 갱신 시도`);
           authRetried = true;
           const refreshed = await this.tryRefreshToken();

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -567,7 +567,12 @@ class ApiClient {
         }
 
         // 401 시 토큰 갱신 후 1회 재시도 (/auth/me 포함, 그 외 인증 엔드포인트 제외)
-        if (response.status === 401 && !authRetried && (!endpoint.startsWith('/auth/') || endpoint === '/auth/me')) {
+        const normalizedEndpoint = endpoint.split('?')[0].replace(/\/+$/, '') || '/';
+        if (
+          response.status === 401 &&
+          !authRetried &&
+          (!normalizedEndpoint.startsWith('/auth/') || normalizedEndpoint === '/auth/me')
+        ) {
           logger.info(`[API Request ${requestId}] 401 → 토큰 갱신 시도`);
           authRetried = true;
           const refreshed = await this.tryRefreshToken();


### PR DESCRIPTION
## Summary
- keep refresh-login behavior on a 30-day retention window
- preserve mobile keyboard focus when navigating into input-heavy creation flows
- switch default production CORS origins to https://www.chamung.com

## Validation
- npm run test:run -- api/__tests__/proxy.test.ts src/hooks/useAutoFocus.test.ts src/lib/api/__tests__/client.test.ts
- npm run build
- npm --workspace backend test -- --runInBand src/auth/auth.controller.spec.ts src/auth/auth.service.spec.ts

## Notes
- Google OAuth console still needs Authorized JavaScript origins to include https://www.chamung.com
- Live OAuth flows were not exercised locally because they require provider-console configuration and production credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 테스트 환경에서 관리자 UI 모듈이 테스트 동안 불필요하게 초기화되는 문제를 수정했습니다.
  * 일부 인증 흐름의 401 처리 시 토큰 갱신 재시도 로직을 개선했습니다.

* **New Features**
  * 모바일 입력 경험을 개선하기 위한 키보드 프록시 및 포커스 준비 기능을 추가했습니다.
  * 빠른 동작 버튼이 특정 편집/작성 페이지로 이동할 때 키보드 준비를 트리거합니다.

* **Tests**
  * 인증 컨트롤러·서비스 및 관련 E2E/단위 테스트를 추가·확장했습니다.

* **Chores**
  * 리프레시 토큰 만료 기간을 7일에서 30일로 연장했고, 테스트 환경 로딩과 SSH 터널 설정 관련 환경 변수 처리를 정리했습니다.
* **Configuration**
  * 허용된 CORS Origin을 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FLYLIKEB/ChaLog/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->