### PR TITLE
fix: avoid noisy auth probes during Kakao callbacks

### DIFF
--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,55 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider, isKakaoLoginCallbackUrl } from './AuthContext';
+import { authApi, usersApi } from '../lib/api';
+
+vi.mock('../lib/api', () => ({
+  authApi: {
+    getMe: vi.fn(),
+  },
+  usersApi: {
+    getOnboardingPreference: vi.fn(),
+  },
+}));
+
+describe('AuthProvider initial session check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/');
+    vi.mocked(authApi.getMe).mockResolvedValue({
+      user: { id: 1, email: 'user@example.com', name: 'User' },
+    });
+    vi.mocked(usersApi.getOnboardingPreference).mockResolvedValue({
+      hasCompletedOnboarding: true,
+    });
+  });
+
+  it('recognizes Kakao login callback URLs only on /login with a code', () => {
+    expect(isKakaoLoginCallbackUrl({ pathname: '/login', search: '?code=abc' })).toBe(true);
+    expect(isKakaoLoginCallbackUrl({ pathname: '/login', search: '' })).toBe(false);
+    expect(isKakaoLoginCallbackUrl({ pathname: '/login', search: '?code=' })).toBe(false);
+    expect(isKakaoLoginCallbackUrl({ pathname: '/settings', search: '?code=abc' })).toBe(false);
+  });
+
+  it('checks the existing session on normal app entry', async () => {
+    render(
+      <AuthProvider>
+        <div>app</div>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(authApi.getMe).toHaveBeenCalledTimes(1));
+  });
+
+  it('skips the initial session check during Kakao login callback handling', async () => {
+    window.history.replaceState({}, '', '/login?code=kakao-code');
+
+    render(
+      <AuthProvider>
+        <div>app</div>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(authApi.getMe).not.toHaveBeenCalled());
+  });
+});

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -45,6 +45,11 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+export function isKakaoLoginCallbackUrl(location: Pick<Location, 'pathname' | 'search'>): boolean {
+  const code = new URLSearchParams(location.search).get('code');
+  return location.pathname === '/login' && !!code?.trim();
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
@@ -53,21 +58,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isOnboardingLoading, setIsOnboardingLoading] = useState(false);
 
   useEffect(() => {
-    // 쿠키 기반 인증: getMe()로 초기 인증 상태 확인
-    authApi.getMe()
-      .then((res) => {
-        setUser(res.user);
-        setToken('cookie'); // 쿠키 인증 활성화 표시
-        localStorage.setItem('user', JSON.stringify(res.user));
-      })
-      .catch(() => {
-        setUser(null);
-        setToken(null);
-        localStorage.removeItem('user');
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
+    const shouldSkipInitialSessionCheck =
+      typeof window !== 'undefined' && isKakaoLoginCallbackUrl(window.location);
+
+    if (shouldSkipInitialSessionCheck) {
+      // 카카오 리다이렉트 직후에는 아직 서버 세션 쿠키가 발급되기 전이다.
+      // 콜백 처리 전에 /auth/me → /auth/refresh 를 먼저 때리면 정상 로그인 직전 401 노이즈만 만든다.
+      setIsLoading(false);
+    } else {
+      // 쿠키 기반 인증: getMe()로 초기 인증 상태 확인
+      authApi.getMe()
+        .then((res) => {
+          setUser(res.user);
+          setToken('cookie'); // 쿠키 인증 활성화 표시
+          localStorage.setItem('user', JSON.stringify(res.user));
+        })
+        .catch(() => {
+          setUser(null);
+          setToken(null);
+          localStorage.removeItem('user');
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
 
     // interval 추적을 위한 변수
     let checkInterval: NodeJS.Timeout | null = null;
@@ -817,4 +831,3 @@ export function useAuth() {
   }
   return context;
 }
-


### PR DESCRIPTION
## Summary
- skip the initial cookie-session probe during real `/login?code=...` Kakao callbacks
- keep normal session revalidation unchanged for ordinary app entries
- add regression tests for callback URL detection and the skipped initial probe

## Validation
- npm run test:run -- src/contexts/AuthContext.test.tsx src/lib/api/__tests__/client.test.ts
- npm run build

## Review notes
- local code review kept the skip narrowly scoped to non-empty `/login` callback codes only
- live Kakao round-trip still needs post-deploy smoke verification