### PR TITLE
Align note detail with shared app chrome

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React, { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { ThemeProvider } from 'next-themes';
-import { PAGE_BG_GRADIENT } from './constants';
 import { Loader2 } from 'lucide-react';
 import { Toaster } from './components/ui/sonner';
 import { GoogleOAuthProvider } from '@react-oauth/google';
@@ -147,7 +146,7 @@ function AppContent() {
 
   return (
     <AppModeProvider>
-      <div className={`h-screen flex flex-col overflow-hidden ${PAGE_BG_GRADIENT}`}>
+      <div className="h-screen flex flex-col overflow-hidden bg-background">
         {/* 메인 콘텐츠 영역 */}
         <div className="flex-1 flex flex-col overflow-hidden min-w-0 md:pl-[160px]">
           <EmailVerificationBannerWrapper />

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -103,7 +103,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
         {comments.map((comment) => {
           const isOwner = user?.id === comment.userId;
           return (
-            <div key={comment.id} className="rounded-xl bg-muted/40 dark:bg-muted/20 px-3.5 py-3">
+            <div key={comment.id} className="rounded-xl px-0 py-3 border-b border-border/20 last:border-b-0">
               <div className="flex gap-2.5">
                 {/* 프로필 아바타 */}
                 <CommentAvatar
@@ -218,9 +218,9 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
       {user ? (
         <form
           onSubmit={handleSubmit}
-          className="fixed bottom-[var(--bottom-nav-spacer)] left-0 right-0 bg-surface-strong dark:bg-surface-strong border-t border-border/40 px-4 py-2.5 z-20"
+          className="fixed bottom-[var(--bottom-nav-spacer)] left-0 right-0 bg-background/80 backdrop-blur-md px-4 py-2.5 z-20"
         >
-          <div className="flex items-center gap-0 bg-card rounded-full overflow-hidden pl-3 pr-1">
+          <div className="flex items-center gap-0 bg-muted/30 rounded-full overflow-hidden pl-3 pr-1">
             {/* 닉네임 라벨 */}
             <span className="text-xs font-semibold text-primary shrink-0 pr-2">
               {user.name}

--- a/src/components/TeaListCard.tsx
+++ b/src/components/TeaListCard.tsx
@@ -27,7 +27,7 @@ export const TeaListCard: FC<TeaListCardProps> = ({ tea, rank, isNew }) => {
     <button
       type="button"
       onClick={() => navigate(`/tea/${tea.id}`)}
-      className="w-full flex items-center gap-3 px-3 py-3 rounded-xl bg-card border border-border/30 hover:border-primary/20 hover:shadow-sm active:scale-[0.99] transition-all text-left"
+      className="w-full flex items-center gap-3 px-3 py-3 rounded-xl bg-card border-0 active:scale-[0.99] transition-all text-left"
     >
       {/* 랭킹 또는 NEW 뱃지 */}
       {rank != null && (

--- a/src/components/home/WeeklyStreak.tsx
+++ b/src/components/home/WeeklyStreak.tsx
@@ -80,7 +80,7 @@ export function WeeklyStreak({ onTodayNoteStatus, onStreakLoaded }: WeeklyStreak
   const selectedDateKey = formatDateKey(selectedDate);
 
   return (
-    <div className="rounded-sm bg-card border-0 p-4 md:p-5">
+    <div className="rounded-sm bg-background/40 backdrop-blur-md border border-foreground/[0.04] p-4 md:p-5">
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">

--- a/src/components/profile/ProfileZone.tsx
+++ b/src/components/profile/ProfileZone.tsx
@@ -70,7 +70,7 @@ export function ProfileZone({
   return (
     <div>
       {/* Gradient banner */}
-      <div className="h-16 bg-gradient-to-br from-primary/8 via-amber-50/30 to-transparent dark:from-primary/10 dark:via-stone-900/20 dark:to-transparent" />
+      <div className="h-16" />
 
       <div className="px-4 -mt-8 pb-4 space-y-3">
 

--- a/src/pages/NoteDetail.tsx
+++ b/src/pages/NoteDetail.tsx
@@ -1,14 +1,14 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Star, Trash2, Globe, Lock, Loader2, Heart, Bookmark, Edit, Flag, Share2 } from 'lucide-react';
+import { Star, Trash2, Loader2, Heart, Bookmark, Edit, Flag, Share2 } from 'lucide-react';
 import { Header } from '../components/Header';
 import { DetailFallback } from '../components/DetailFallback';
 import { RatingVisualization } from '../components/RatingVisualization';
-import { ImageWithFallback } from '../components/figma/ImageWithFallback';
 import { ImageCarousel } from '../components/ImageCarousel';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import { ReportModal } from '../components/ReportModal';
+import { BottomNav } from '../components/BottomNav';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -112,7 +112,7 @@ export function NoteDetail() {
 
   if (!note) {
     return (
-      <DetailFallback 
+      <DetailFallback
         title="차록 상세"
         message="차록을 찾을 수 없거나 볼 권한이 없습니다."
       />
@@ -126,7 +126,6 @@ export function NoteDetail() {
       toast.error('유효하지 않은 차록 ID입니다.');
       return;
     }
-
     try {
       setIsUpdating(true);
       await notesApi.update(noteId, { isPublic: !note.isPublic });
@@ -145,13 +144,11 @@ export function NoteDetail() {
       toast.error('유효하지 않은 차록 ID입니다.');
       return;
     }
-
     try {
       setIsDeleting(true);
       await notesApi.delete(noteId);
-      setIsDeleted(true); // 삭제 상태 설정하여 API 재호출 방지
+      setIsDeleted(true);
       toast.success('차록이 삭제되었습니다.');
-      // 이전 화면으로 돌아가기
       navigate(-1);
     } catch (error) {
       logger.error('Failed to delete note:', error);
@@ -166,9 +163,7 @@ export function NoteDetail() {
       toast.error('로그인이 필요합니다.');
       return;
     }
-
     if (isTogglingLike || isNaN(noteId)) return;
-
     try {
       setIsTogglingLike(true);
       const result = await notesApi.toggleLike(noteId);
@@ -187,11 +182,7 @@ export function NoteDetail() {
       toast.error('로그인이 필요합니다.');
       return;
     }
-
-    if (isTogglingBookmark || isNaN(noteId)) {
-      return;
-    }
-
+    if (isTogglingBookmark || isNaN(noteId)) return;
     try {
       setIsTogglingBookmark(true);
       const result = await notesApi.toggleBookmark(noteId);
@@ -215,6 +206,8 @@ export function NoteDetail() {
   const dateWeekday = ['일', '월', '화', '수', '목', '금', '토'][displayDate.getDay()];
 
   const brewColor = note.appearance ? BREW_COLORS.find((c) => c.value === note.appearance) : null;
+
+  // 메모 첫 줄 (72자 제한)
   const memoQuoteSource = note.memo
     ?.split(/\n+/)
     .map((line) => line.replace(/[#>*_`~\-[\]()]/g, '').replace(/\s+/g, ' ').trim())
@@ -226,7 +219,7 @@ export function NoteDetail() {
     : null;
 
   return (
-    <div className="note-detail-scene relative min-h-dvh overflow-hidden pb-6 text-white">
+    <div className="note-detail-scene relative min-h-dvh overflow-hidden pb-6 bg-background text-foreground">
       <div className="note-detail-ambient" aria-hidden />
       <div className="note-detail-ripples" aria-hidden>
         <span className="note-detail-ripple note-detail-ripple-1" />
@@ -234,280 +227,136 @@ export function NoteDetail() {
         <span className="note-detail-ripple note-detail-ripple-3" />
         <span className="note-detail-ripple note-detail-ripple-4" />
       </div>
-      <div className="note-detail-geometry-field" aria-hidden>
-        <span className="note-detail-geo note-detail-geo-ring" />
-        <span className="note-detail-geo note-detail-geo-disc" />
-        <span className="note-detail-geo note-detail-geo-slab" />
-        <span className="note-detail-geo note-detail-geo-line" />
-        <span className="note-detail-geo note-detail-geo-triangle" />
-        <span className="note-detail-geo note-detail-geo-dots" />
-      </div>
 
-      <Header showBack title="차록" showProfile tone="glassDark" />
+      <Header showBack title="차록" showProfile />
 
-      <div className="relative z-10 mx-auto max-w-[430px] px-3 py-4 sm:px-4">
-        {/* 일기장 카드 - 하나의 통합 카드 */}
+      <div className="relative z-10 pt-2 pb-4">
+        {/* 글라스 카드 래퍼 + 횡스크롤 카드 덱 */}
         <article className="note-detail-glass-card relative overflow-hidden">
-          <div className="note-detail-card-deck" aria-label="차록 상세 콘텐츠">
+        <div className="note-detail-card-deck" aria-label="차록 상세 콘텐츠">
 
-          {/* 차 이름 / 한줄평 */}
-          <section className="note-detail-hero px-5 pb-6 pt-3">
-            {/* 향미태그 기반 레이더/점수 형태 배경 글로우 */}
-            {(() => {
-              // 대만 특색차 풍미 → 색상 매핑
-              const TAG_COLORS: Record<string, string> = {
-                // 꽃향
-                '꽃향': '255,240,210', '장미': '255,182,185', '재스민': '240,248,200',
-                '라일락': '210,195,230', '국화': '255,230,130', '아카시아': '245,235,190',
-                '목서화': '255,185,80',
-                // 과일향
-                '과일향': '255,210,140', '복숭아': '255,195,150', '사과': '220,235,160',
-                '배': '235,240,180', '레몬': '255,245,130', '오렌지': '255,165,80',
-                '포도': '160,100,160', '딸기': '240,120,120', '매실': '180,80,100',
-                '리치': '255,200,200', '망고': '255,190,60',
-                // 견과/곡물
-                '견과류': '195,155,100', '볶은향': '165,115,65', '호두': '130,85,50',
-                '아몬드': '215,175,120', '곡물': '220,195,140', '쌀': '240,225,185',
-                '보리': '200,170,110',
-                // 풀/채소
-                '풀향': '160,205,120', '녹차향': '140,195,110', '해조류': '80,140,110',
-                '채소': '130,175,90', '허브': '100,170,130',
-                // 나무/흙
-                '나무향': '160,120,80', '흙향': '140,105,70', '이끼': '100,130,80',
-                '습한흙': '120,100,75',
-                // 향신료
-                '향신료': '210,110,70', '계피': '185,90,50', '생강': '225,160,80',
-                '정향': '120,65,45', '후추': '90,70,60',
-                // 달콤/캐러멜
-                '달콤함': '255,220,160', '캐러멜': '210,145,70', '꿀': '240,185,80',
-                '바닐라': '245,225,190', '초콜릿': '105,55,35', '엿': '190,140,80',
-                // 스모키
-                '스모키': '85,75,65', '훈연향': '120,85,60', '숯': '55,50,45',
-                // 발효/숙성
-                '발효향': '130,85,55', '된장': '155,120,75', '숙성향': '110,80,55',
-                // 광물/청량
-                '광물향': '170,200,210', '청량감': '200,235,230', '시원함': '185,220,225',
-              };
+          {/* ── 카드 1: HERO ── */}
+          <section className="note-detail-hero px-4 pb-5 pt-4">
 
-              const tags = note.tags ?? [];
-              const matched = tags
-                .map(t => TAG_COLORS[t] ? { rgb: TAG_COLORS[t], tag: t } : null)
-                .filter(Boolean)
-                .slice(0, 4) as { rgb: string; tag: string }[];
-              const colorEntries = matched.length > 0 ? matched : [{ rgb: '232,203,139', tag: '' }];
-
-              const axes = note.axisValues ?? [];
-              const sorted = [...axes].sort((a, b) => (a.axis?.displayOrder ?? 0) - (b.axis?.displayOrder ?? 0));
-              const cx = 50; const cy = 50; const r = 38;
-
-              // 태그 타원 위치: 형태 안에서 분산 배치 (중심 기준 상대 오프셋)
-              const tagPositions = [
-                { ox: 0,   oy: -12 },  // 상단
-                { ox: 12,  oy: 8  },   // 우하단
-                { ox: -12, oy: 8  },   // 좌하단
-                { ox: 0,   oy: 16 },   // 하단
-              ];
-
-              // 타원: 카드 너비만큼 크게, 하단으로 내림
-              const renderTagEllipses = () => {
-                // 태그 개수에 따라 y 위치 분산 (cx=50 기준, 하단부에 몰아서 배치)
-                const yPositions = [72, 82, 88, 94];
-                return colorEntries.map(({ rgb, tag }, i) => {
-                  const ey = yPositions[i] ?? 80;
-                  const ex = 50;
-                  const filterId = `tag-blur-${i}`;
-                  return (
-                    <g key={i}>
-                      <defs>
-                        <filter id={filterId} x="-30%" y="-100%" width="160%" height="300%">
-                          <feGaussianBlur stdDeviation="7" />
-                        </filter>
-                      </defs>
-                      {/* rx=48: 거의 카드 전체 너비, ry=10: 옆으로 납작한 타원 */}
-                      <ellipse cx={ex} cy={ey} rx={48} ry={10} fill={`rgba(${rgb},0.72)`} filter={`url(#${filterId})`} />
-                      {tag && (
-                        <text x={ex} y={ey} textAnchor="middle" dominantBaseline="middle"
-                          fontSize="3.2" fontWeight="700" letterSpacing="0.06em"
-                          fill={`rgba(${rgb},0.42)`}
-                          style={{ fontFamily: 'inherit', userSelect: 'none' }}>
-                          {tag}
-                        </text>
-                      )}
-                    </g>
-                  );
-                });
-              };
-
-              if (sorted.length >= 3) {
-                const points = sorted.map((av, i) => {
-                  const angle = (Math.PI * 2 * i) / sorted.length - Math.PI / 2;
-                  const max = Number(av.axis?.maxValue) || 5;
-                  const val = Math.max(0, Math.min(max, Number(av.valueNumeric) || 0));
-                  const ratio = val / max;
-                  return `${cx + r * ratio * Math.cos(angle)},${cy + r * ratio * Math.sin(angle)}`;
-                }).join(' ');
-                return (
-                  <svg aria-hidden className="pointer-events-none absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
-                    <defs>
-                      <filter id="hero-shape-blur" x="-40%" y="-40%" width="180%" height="180%">
-                        <feGaussianBlur stdDeviation="5" />
-                      </filter>
-                    </defs>
-                    {/* polygon 형태 — blur로 바깥도 부드럽게 */}
-                    <polygon points={points} fill="rgba(255,255,255,0.07)" filter="url(#hero-shape-blur)" />
-                    {renderTagEllipses()}
-                  </svg>
-                );
-              }
-              const rating = note.overallRating != null ? Number(note.overallRating) : null;
-              if (rating != null && rating > 0) {
-                const ratio = rating / 5;
-                const rr = 14 + ratio * 26;
-                return (
-                  <svg aria-hidden className="pointer-events-none absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
-                    <defs>
-                      <filter id="hero-circle-blur" x="-40%" y="-40%" width="180%" height="180%">
-                        <feGaussianBlur stdDeviation="5" />
-                      </filter>
-                    </defs>
-                    <circle cx={cx} cy={cy} r={rr} fill="rgba(255,255,255,0.07)" filter="url(#hero-circle-blur)" />
-                    {renderTagEllipses()}
-                  </svg>
-                );
-              }
-              return null;
-            })()}
-            <div className="note-detail-hero-composition" aria-hidden>
-              <span className="note-detail-composition-ring" />
-              <span className="note-detail-composition-bar" />
-              <span className="note-detail-composition-axis" />
-              <span className="note-detail-composition-block" />
-            </div>
-            <div className="note-detail-enter note-detail-enter-1 flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <p className="note-detail-exhibition-label text-[10px] font-semibold uppercase tracking-[0.34em] text-white/35">TASTING LOG</p>
-                <button
-                  type="button"
-                  onClick={() => navigate(`/user/${note.userId}`)}
-                  className="mt-2 inline-flex rounded-full border border-white/10 bg-white/[0.035] px-3 py-1 text-xs text-white/55 transition hover:bg-white/10 hover:text-white"
-                >
-                  {note.userName}
-                </button>
-              </div>
-              <div className="flex flex-col items-end gap-2">
-                <span className="note-detail-privacy-chip">
-                  {note.isPublic ? <Globe className="h-3 w-3" /> : <Lock className="h-3 w-3" />}
-                  {note.isPublic ? 'PUBLIC' : 'PRIVATE'}
-                </span>
-                <span className="text-right text-xs leading-tight text-white/45">
-                  {dateYear}.{String(dateMonth).padStart(2, '0')}.{String(dateDay).padStart(2, '0')}<br />
-                  {dateWeekday}요일
-                </span>
+            {/* 상단: 작성자 + 공개여부 + 날짜 */}
+            <div className="flex items-start justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => navigate(`/user/${note.userId}`)}
+                className="text-xs font-medium text-muted-foreground hover:text-primary cursor-pointer transition-colors"
+              >
+                {note.userName}
+              </button>
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <span>{note.isPublic ? 'PUBLIC' : 'PRIVATE'}</span>
+                <span>{dateYear}.{String(dateMonth).padStart(2, '0')}.{String(dateDay).padStart(2, '0')}</span>
               </div>
             </div>
 
-            <div className="note-detail-enter note-detail-enter-2 mt-4 flex items-end justify-between gap-4">
+            {/* 차 이름 + 평점 */}
+            <div className="mt-4 flex items-start justify-between gap-3">
               <div className="min-w-0">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-white/35">Tea</p>
                 {tea ? (
                   <button
                     type="button"
                     onClick={() => navigate(`/tea/${tea.id}`)}
-                    className="note-detail-tea-link mt-1 block text-left"
+                    className="text-left"
                   >
-                    <h2 className="note-detail-tea-title text-white"><span>{tea.name}</span></h2>
+                    <h2 className="text-xl font-bold text-foreground leading-tight">{tea.name}</h2>
                   </button>
                 ) : (
-                  <h2 className="note-detail-tea-title text-white"><span>차록</span></h2>
+                  <h2 className="text-xl font-bold text-foreground leading-tight">차록</h2>
                 )}
               </div>
-
               {note.overallRating !== null && (
-                <div className="note-detail-score-orb" aria-label={`평점 ${Number(note.overallRating).toFixed(1)}점`}>
-                  <Star className="h-3.5 w-3.5 fill-white text-white/90" />
-                  <strong>
-                    {use10Scale
-                      ? (Number(note.overallRating) * 2).toFixed(1)
-                      : Number(note.overallRating).toFixed(1)}
-                  </strong>
-                  <span>/ {use10Scale ? '10' : '5'}</span>
+                <div className="shrink-0 flex items-center gap-1 text-foreground">
+                  <Star className="h-4 w-4 fill-rating text-rating" />
+                  <span className="text-lg font-bold">{Number(note.overallRating).toFixed(1)}</span>
+                  <span className="text-xs text-muted-foreground">/ 5</span>
                 </div>
               )}
             </div>
 
-            {memoQuote && (
-              <figure className="note-detail-quote note-detail-enter note-detail-enter-3 mt-4">
-                <span className="note-detail-quote-mark" aria-hidden>“</span>
-                <blockquote>{memoQuote}</blockquote>
-              </figure>
-            )}
-
-            <div className="note-detail-tea-meta note-detail-enter note-detail-enter-4 mt-3 flex flex-wrap items-center gap-1.5 text-xs text-white/52">
+            {/* 차 메타 */}
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
               {tea?.type && <TeaTypeBadge type={tea.type} />}
               {tea?.year && <span>{tea.year}년</span>}
               {tea?.seller && (
-                <Link
-                  to={`/teahouse/${encodeURIComponent(tea.seller)}`}
-                  className="text-white/78 underline-offset-4 hover:underline"
-                >
+                <Link to={`/teahouse/${encodeURIComponent(tea.seller)}`} className="text-primary/80 hover:underline underline-offset-4">
                   {tea.seller}
                 </Link>
               )}
             </div>
 
-            <div className="note-detail-chip-rail note-detail-enter note-detail-enter-5 mt-3">
+            {/* 한줄 메모 */}
+            {memoQuote && (
+              <p className="mt-3 text-sm text-foreground/80 leading-snug">"{memoQuote}"</p>
+            )}
+
+            {/* 칩 레일: 날씨 / 수색 / 가격 / 무게 */}
+            <div className="mt-3 flex flex-wrap gap-1.5">
               {weather && (
-                <span className="note-detail-meta-chip">
-                  <span>{weather.emoji}</span>
-                  <span>{weather.label}</span>
+                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-[11px] text-muted-foreground">
+                  {weather.emoji} {weather.label}
                   {weather.temperatureMin != null && weather.temperatureMax != null && (
-                    <span>{weather.temperatureMin}°~{weather.temperatureMax}°</span>
+                    <span className="ml-0.5">{weather.temperatureMin}°~{weather.temperatureMax}°</span>
                   )}
                 </span>
               )}
               {brewColor && (
-                <span className="note-detail-meta-chip">
-                  <span className="h-3 w-3 rounded-full border border-white/20" style={{ backgroundColor: brewColor.hex }} />
-                  <span>{brewColor.label}</span>
+                <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-[11px] text-muted-foreground">
+                  <span className="h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: brewColor.hex }} />
+                  {brewColor.label}
                 </span>
               )}
               {tea?.price != null && tea.price > 0 && (
-                <span className="note-detail-meta-chip">{tea.price.toLocaleString()}원</span>
+                <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-1 text-[11px] text-muted-foreground">{tea.price.toLocaleString()}원</span>
               )}
               {tea?.weight != null && tea.weight > 0 && (
-                <span className="note-detail-meta-chip">{tea.weight}g</span>
+                <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-1 text-[11px] text-muted-foreground">{tea.weight}g</span>
               )}
             </div>
 
-            {note.axisValues && note.axisValues.length > 0 && (
-              <div className="note-detail-signal-wave note-detail-enter note-detail-enter-6" aria-label="맛 프로파일 요약">
-                {[...note.axisValues]
-                  .sort((a, b) => (a.axis?.displayOrder ?? 0) - (b.axis?.displayOrder ?? 0))
-                  .slice(0, 9)
-                  .map((axisValue) => {
-                    const value = Math.max(0, Math.min(5, Number(axisValue.value) || 0));
-                    return (
-                      <span
-                        key={axisValue.axisId}
-                        title={`${axisValue.axis?.nameKo ?? '평가축'} ${value.toFixed(1)}`}
-                        style={{ height: `${18 + value * 13}%` }}
-                      />
-                    );
-                  })}
+            {/* 향미 태그 */}
+            {note.tags && note.tags.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-1">
+                {note.tags.slice(0, 6).map((tag, i) => (
+                  <Link key={i} to={`/tag/${encodeURIComponent(tag)}`}>
+                    <Badge variant="secondary" className="cursor-pointer text-[11px]">
+                      {tag}
+                    </Badge>
+                  </Link>
+                ))}
+                {note.tags.length > 6 && (
+                  <Badge variant="secondary" className="text-[11px] text-muted-foreground">
+                    +{note.tags.length - 6}
+                  </Badge>
+                )}
               </div>
             )}
+
           </section>
 
+          {/* ── 카드 2: NOTE (메모 + 이미지) ── */}
           {(note.memo || (note.images && note.images.length > 0)) && (
-            <section className="note-detail-story-card note-detail-enter note-detail-enter-7 px-5 pt-4 pb-5">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-white/35">NOTE</p>
+            <section className="note-detail-story-card px-5 pt-4 pb-5">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-[9px] font-bold uppercase tracking-[0.32em] text-muted-foreground">NOTE</p>
                 {note.images && note.images.length > 0 && (
-                  <span className="text-[10px] uppercase tracking-[0.2em] text-white/30">{note.images.length} Photo</span>
+                  <span className="text-[9px] uppercase tracking-[0.2em] text-muted-foreground">{note.images.length} Photo</span>
                 )}
               </div>
               {note.memo && (
-                <div className="note-detail-prose text-[0.96rem] leading-[1.78] text-white/90 [&_p]:my-1 [&_p]:whitespace-pre-wrap [&_h1]:mt-3 [&_h1]:mb-1.5 [&_h1]:text-lg [&_h1]:font-bold [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h2]:text-base [&_h2]:font-semibold [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-semibold [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-0.5 [&_code]:rounded [&_code]:bg-white/10 [&_code]:px-1 [&_code]:text-xs [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-white/10 [&_pre]:p-3 [&_a]:text-white [&_a]:underline [&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-white/20 [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-white/60 [&_table]:my-3 [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-white/10 [&_th]:bg-white/10 [&_th]:px-3 [&_th]:py-1.5 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_td]:border [&_td]:border-white/10 [&_td]:px-3 [&_td]:py-1.5 [&_td]:text-xs">
+                <div className="note-detail-prose text-[0.92rem] leading-[1.75] text-foreground
+                  [&_p]:my-1 [&_p]:whitespace-pre-wrap
+                  [&_h1]:mt-3 [&_h1]:mb-1.5 [&_h1]:text-lg [&_h1]:font-bold
+                  [&_h2]:mt-2.5 [&_h2]:mb-1 [&_h2]:text-base [&_h2]:font-semibold
+                  [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5
+                  [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5
+                  [&_li]:my-0.5
+                  [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:text-xs
+                  [&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-muted-foreground
+                  [&_a]:text-primary [&_a]:underline">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{note.memo}</ReactMarkdown>
                 </div>
               )}
@@ -519,72 +368,63 @@ export function NoteDetail() {
             </section>
           )}
 
-          {((note.axisValues && note.axisValues.length > 0) || brewColor || (note.tags && note.tags.length > 0) || weather?.teaComment) && (
+          {/* ── 카드 3: PROFILE (향미 그래프 + 태그) ── */}
+          {((note.axisValues && note.axisValues.length > 0) || (note.tags && note.tags.length > 0) || weather?.teaComment) && (
             <section className="note-detail-profile-card note-detail-section note-detail-section-axis space-y-3 px-5 pt-4 pb-5">
-              <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center justify-between">
                 <div>
-                  <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-white/35">PROFILE</p>
-                  <p className="text-sm font-medium text-white/82">감각 프로필</p>
+                  <p className="text-[9px] font-bold uppercase tracking-[0.32em] text-muted-foreground">PROFILE</p>
+                  <p className="mt-0.5 text-sm font-medium text-foreground">감각 프로필</p>
                 </div>
-                {brewColor && (
-                  <div className="flex items-center gap-2 text-right text-xs text-white/55">
-                    <span className="inline-block h-5 w-5 rounded-full border border-white/15" style={{ backgroundColor: brewColor.hex }} />
-                    <span>{brewColor.label}</span>
+                {note.axisValues && note.axisValues.length > 0 && (
+                  <div role="group" className="note-detail-scale-toggle flex p-0.5">
+                    <button
+                      type="button"
+                      aria-pressed={!use10Scale}
+                      onClick={() => setUse10Scale(false)}
+                      className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${!use10Scale ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+                    >
+                      5점
+                    </button>
+                    <button
+                      type="button"
+                      aria-pressed={use10Scale}
+                      onClick={() => setUse10Scale(true)}
+                      className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${use10Scale ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+                    >
+                      10점
+                    </button>
                   </div>
                 )}
               </div>
 
               {note.axisValues && note.axisValues.length > 0 && (
                 <>
-                  <div className="flex items-center justify-between gap-3">
-                    {((note.schemas?.length ?? 0) > 0 || note.schema) ? (
-                      <div className="min-w-0 flex-1 rounded-lg bg-white/[0.04] px-3 py-2">
-                        <p className="mb-0.5 text-[10px] uppercase tracking-wider text-white/35">템플릿</p>
-                        {(note.schemas?.length ?? 0) > 0 ? (
-                          <div className="flex flex-wrap gap-1">
-                            {note.schemas!.map((s) => (
-                              <span key={s.id} className="text-xs font-medium text-white">{s.nameKo}</span>
-                            ))}
-                          </div>
-                        ) : note.schema && (
-                          <span className="text-xs font-medium text-white">{note.schema.nameKo}</span>
-                        )}
-                      </div>
-                    ) : <div />}
-                    <div role="group" aria-label="점수 표시 단위" className="note-detail-scale-toggle flex p-0.5">
-                      <button
-                        type="button"
-                        aria-pressed={!use10Scale}
-                        onClick={() => setUse10Scale(false)}
-                        className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
-                          !use10Scale ? 'text-white' : 'text-white/38 hover:text-white/82'
-                        }`}
-                      >
-                        5점
-                      </button>
-                      <button
-                        type="button"
-                        aria-pressed={use10Scale}
-                        onClick={() => setUse10Scale(true)}
-                        className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
-                          use10Scale ? 'text-white' : 'text-white/38 hover:text-white/82'
-                        }`}
-                      >
-                        10점
-                      </button>
+                  {((note.schemas?.length ?? 0) > 0 || note.schema) && (
+                    <div className="rounded-lg bg-muted px-3 py-2">
+                      <p className="mb-0.5 text-[9px] uppercase tracking-wider text-muted-foreground">템플릿</p>
+                      {(note.schemas?.length ?? 0) > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {note.schemas!.map((s) => (
+                            <span key={s.id} className="text-xs font-medium text-foreground">{s.nameKo}</span>
+                          ))}
+                        </div>
+                      ) : note.schema && (
+                        <span className="text-xs font-medium text-foreground">{note.schema.nameKo}</span>
+                      )}
                     </div>
-                  </div>
+                  )}
                   <RatingVisualization axisValues={note.axisValues} use10Scale={use10Scale} variant="poster" />
                 </>
               )}
 
               {note.tags && note.tags.length > 0 && (
                 <div className="note-detail-section-tags pt-1">
-                  <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.28em] text-white/35">FLAVOR TRACE</p>
+                  <p className="mb-2 text-[9px] font-bold uppercase tracking-[0.3em] text-muted-foreground">FLAVOR TRACE</p>
                   <div className="flex flex-wrap gap-1.5">
                     {note.tags.map((tag, index) => (
                       <Link key={index} to={`/tag/${encodeURIComponent(tag)}`}>
-                        <Badge variant="secondary" className="cursor-pointer border-white/10 bg-white/[0.06] text-xs text-white transition-colors hover:bg-white/[0.12]">
+                        <Badge variant="secondary" className="cursor-pointer text-xs">
                           {tag}
                         </Badge>
                       </Link>
@@ -594,132 +434,121 @@ export function NoteDetail() {
               )}
 
               {weather?.teaComment && (
-                <p className="pt-1 text-xs italic leading-relaxed text-white/45">&ldquo;{weather.teaComment}&rdquo;</p>
+                <p className="pt-1 text-xs italic leading-relaxed text-muted-foreground">&ldquo;{weather.teaComment}&rdquo;</p>
               )}
             </section>
           )}
+        </div>
 
-          </div>
-
-          {/* 좋아요 / 북마크 / 공유 - 카드 하단 */}
-          {user && (
-            <div className="note-detail-action-dock mx-3 mb-3 mt-3 flex items-center justify-center gap-3 px-3 py-2.5">
-              <button
-                type="button"
-                onClick={handleLikeClick}
-                disabled={isTogglingLike}
-                className={`min-h-[40px] flex items-center justify-center gap-1.5 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${
-                  isLiked ? 'text-primary' : 'text-white/45 hover:text-white'
-                }`}
-                title={isLiked ? '좋아요 취소' : '좋아요'}
-              >
-                <Heart className={`w-4.5 h-4.5 transition-all ${isLiked ? 'fill-primary text-primary' : 'fill-none'}`} />
-                {likeCount > 0 && <span className="text-xs font-medium">{likeCount}</span>}
-              </button>
-              <button
-                type="button"
-                onClick={handleBookmarkClick}
-                disabled={isTogglingBookmark}
-                className={`min-h-[40px] min-w-[40px] flex items-center justify-center px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${
-                  isBookmarked ? 'text-primary' : 'text-white/45 hover:text-white'
-                }`}
-                title={isBookmarked ? '북마크 해제' : '북마크 추가'}
-              >
-                <Bookmark className={`w-4.5 h-4.5 transition-all ${isBookmarked ? 'fill-primary text-primary' : 'fill-none'}`} />
-              </button>
-              <button
-                type="button"
-                onClick={() => share(tea?.name ?? '차록', window.location.href)}
-                className="flex min-h-[40px] min-w-[40px] items-center justify-center rounded-lg px-4 py-2 text-white/45 transition-colors hover:text-white"
-                title="공유하기"
-              >
-                <Share2 className="w-4.5 h-4.5" />
-              </button>
+        {/* 페이지 인디케이터 */}
+        {(() => {
+          const cardCount = [
+            true,
+            !!(note.memo || (note.images && note.images.length > 0)),
+            !!(note.axisValues && note.axisValues.length > 0),
+          ].filter(Boolean).length;
+          if (cardCount <= 1) return null;
+          return (
+            <div className="flex items-center justify-center gap-1.5 py-2">
+              {Array.from({ length: cardCount }).map((_, i) => (
+                <span
+                  key={i}
+                  className="h-1.5 w-1.5 rounded-full bg-foreground/25"
+                />
+              ))}
             </div>
-          )}
-        </article>
+          );
+        })()}
 
-        {/* 카드 밖: 신고 / 수정 / 삭제 */}
-        <div className="mt-3 space-y-2">
-          {/* 다른 사람 노트일 때 신고 */}
+        {/* 액션 독 */}
+        {user && (
+          <div className="note-detail-action-dock mx-3 mb-3 mt-1 flex items-center justify-center gap-2 px-3 py-2">
+            <button
+              type="button"
+              onClick={handleLikeClick}
+              disabled={isTogglingLike}
+              className={`min-h-[40px] flex items-center justify-center gap-1.5 px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${isLiked ? 'text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+            >
+              <Heart className={`w-[18px] h-[18px] transition-all ${isLiked ? 'fill-primary text-primary' : ''}`} />
+              {likeCount > 0 && <span className="text-xs font-medium">{likeCount}</span>}
+            </button>
+            <button
+              type="button"
+              onClick={handleBookmarkClick}
+              disabled={isTogglingBookmark}
+              className={`min-h-[40px] min-w-[40px] flex items-center justify-center px-4 py-2 rounded-lg transition-colors disabled:opacity-50 ${isBookmarked ? 'text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+            >
+              <Bookmark className={`w-[18px] h-[18px] transition-all ${isBookmarked ? 'fill-primary text-primary' : ''}`} />
+            </button>
+            <button
+              type="button"
+              onClick={() => share(tea?.name ?? '차록', window.location.href)}
+              className="flex min-h-[40px] min-w-[40px] items-center justify-center px-4 py-2 rounded-lg text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Share2 className="w-[18px] h-[18px]" />
+            </button>
+          </div>
+        )}
+
+        {/* 카드 밖: 수정/삭제/신고 */}
+        <div className="mt-3 space-y-2 px-4">
           {user && !isMyNote && (
             <div className="flex justify-end">
               <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => setShowReportModal(true)}
-                className="gap-1.5 text-white/45 hover:bg-white/10 hover:text-white"
+                className="gap-1.5 text-muted-foreground hover:text-foreground"
               >
-                <Flag className="w-3.5 h-3.5" />
-                신고하기
+                <Flag className="w-3.5 h-3.5" />신고하기
               </Button>
             </div>
           )}
 
-          {/* 내 노트 액션 */}
           {isMyNote && !isAuthLoading && (
             <div className="flex gap-2">
               <Button
                 variant="outline"
                 onClick={() => navigate(`/note/${noteId}/edit`)}
-                className="min-h-[44px] flex-1 border-white/15 bg-white/[0.04] text-white hover:bg-white/10 hover:text-white"
+                className="min-h-[44px] flex-1"
               >
-                <Edit className="w-4 h-4 mr-2" />
-                수정
+                <Edit className="w-4 h-4 mr-2" />수정
               </Button>
               <Button
                 variant="outline"
                 onClick={handleTogglePublic}
-                className="min-h-[44px] flex-1 border-white/15 bg-white/[0.04] text-white hover:bg-white/10 hover:text-white"
+                className="min-h-[44px] flex-1"
                 disabled={isUpdating}
               >
-                {isUpdating ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  note.isPublic ? '비공개로 전환' : '공개하기'
-                )}
+                {isUpdating ? <Loader2 className="w-4 h-4 animate-spin" /> : (note.isPublic ? '비공개로 전환' : '공개하기')}
               </Button>
               <Button
                 variant="outline"
                 onClick={() => setShowDeleteDialog(true)}
-                className="min-h-[44px] min-w-[44px] border-white/15 bg-white/[0.04] px-3 hover:bg-red-500/10"
+                className="min-h-[44px] min-w-[44px] px-3 hover:bg-destructive/10 hover:text-destructive"
                 aria-label="삭제"
               >
-                <Trash2 className="w-4.5 h-4.5 text-red-500" />
+                <Trash2 className="w-4.5 h-4.5 text-red-400" />
               </Button>
             </div>
           )}
         </div>
+        </article>
       </div>
 
-      {/* 신고 모달 */}
-      <ReportModal
-        open={showReportModal}
-        onOpenChange={setShowReportModal}
-        noteId={noteId}
-      />
+      <ReportModal open={showReportModal} onOpenChange={setShowReportModal} noteId={noteId} />
+      <BottomNav />
 
-      {/* 삭제 확인 다이얼로그 */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>차록 삭제</AlertDialogTitle>
-            <AlertDialogDescription>
-              정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
-            </AlertDialogDescription>
+            <AlertDialogDescription>정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>취소</AlertDialogCancel>
-            <AlertDialogAction 
-              onClick={handleDelete} 
-              className="bg-red-600 hover:bg-red-700"
-              disabled={isDeleting}
-            >
-              {isDeleting ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                '삭제'
-              )}
+            <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700" disabled={isDeleting}>
+              {isDeleting ? <Loader2 className="w-4 h-4 animate-spin" /> : '삭제'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -192,7 +192,7 @@ export function UserProfile() {
           title={isOwnProfile ? '내 차록' : '사용자 프로필'}
         />
         {/* Profile Zone skeleton */}
-        <div className="h-16 bg-gradient-to-br from-primary/8 via-amber-50/30 to-transparent dark:from-primary/10 dark:via-stone-900/20 dark:to-transparent" />
+        <div className="h-16" />
         <div className="px-4 -mt-8 pb-4 space-y-3">
           <div className="flex items-center gap-4">
             <div className="w-[72px] h-[72px] rounded-full bg-muted animate-pulse shrink-0 ring-2 ring-background" />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,38 +9,38 @@
   --card-shadow-hover: none;
   --card-shadow-top: none;
   --card-radius: 0.18rem;
-  --card-border: rgba(43, 41, 38, 0.12);
-  --background: #f4f0e9;
-  --foreground: #2b2926;
-  --card: #fffdf8;
-  --card-foreground: #2b2926;
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.26 0.012 55);
-  --primary: #2b2926;
-  --primary-foreground: #fffaf0;
-  --secondary: #ebe5dc;
-  --secondary-foreground: #34312c;
-  --muted: #eee8df;
-  --muted-foreground: #6b6358;
-  --accent: #ded7cc;
-  --accent-foreground: #2b2926;
-  --surface-strong: #d4cbc0;
-  --destructive: #6f514c;
+  --card-border: rgba(0, 0, 0, 0.10);
+  --background: #f2f2f2;
+  --foreground: #1a1a1a;
+  --card: #ffffff;
+  --card-foreground: #1a1a1a;
+  --popover: #ffffff;
+  --popover-foreground: #1a1a1a;
+  --primary: #1a1a1a;
+  --primary-foreground: #ffffff;
+  --secondary: #e8e8e8;
+  --secondary-foreground: #1a1a1a;
+  --muted: #ebebeb;
+  --muted-foreground: #6b6b6b;
+  --accent: #e0e0e0;
+  --accent-foreground: #1a1a1a;
+  --surface-strong: #d0d0d0;
+  --destructive: #6b3a3a;
   --destructive-foreground: #ffffff;
-  --border: rgba(43, 41, 38, 0.11);
+  --border: rgba(0, 0, 0, 0.10);
   --input: transparent;
-  --input-background: #f3f0ec;
-  --switch-background: #cdc9c3;
+  --input-background: #efefef;
+  --switch-background: #c8c8c8;
   --font-weight-medium: 500;
   --font-weight-normal: 400;
-  --ring: #8a8174;
-  --rating: #67645d;
-  --success: #686760;
-  --chart-1: #4a4843;
-  --chart-2: #66625a;
-  --chart-3: #817b70;
-  --chart-4: #aaa397;
-  --chart-5: #c9c1b5;
+  --ring: #888888;
+  --rating: #555555;
+  --success: #555555;
+  --chart-1: #3a3a3a;
+  --chart-2: #5a5a5a;
+  --chart-3: #7a7a7a;
+  --chart-4: #9a9a9a;
+  --chart-5: #bababa;
   --radius: 0.18rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
@@ -56,29 +56,29 @@
   --card-shadow: none;
   --card-shadow-hover: none;
   --card-shadow-top: none;
-  --card-border: rgba(246, 241, 232, 0.11);
-  --background: #151412;
-  --foreground: #f6f1e8;
-  --card: #1d1b18;
-  --card-foreground: #f6f1e8;
-  --popover: #1d1b18;
-  --popover-foreground: #f6f1e8;
-  --primary: #eee7db;
-  --primary-foreground: #171512;
-  --secondary: #2b2823;
-  --secondary-foreground: #f6f1e8;
-  --muted: #292621;
-  --muted-foreground: #b7ad9e;
-  --accent: #353127;
-  --accent-foreground: #f6f1e8;
-  --surface-strong: #3d382f;
-  --destructive: #9a8178;
-  --destructive-foreground: #171512;
-  --border: rgba(246, 241, 232, 0.12);
-  --input: oklch(0.269 0 0);
-  --ring: #706858;
-  --rating: #bbb5a9;
-  --success: #aaa498;
+  --card-border: rgba(255, 255, 255, 0.10);
+  --background: #141414;
+  --foreground: #f0f0f0;
+  --card: #1e1e1e;
+  --card-foreground: #f0f0f0;
+  --popover: #1e1e1e;
+  --popover-foreground: #f0f0f0;
+  --primary: #e8e8e8;
+  --primary-foreground: #141414;
+  --secondary: #2a2a2a;
+  --secondary-foreground: #f0f0f0;
+  --muted: #272727;
+  --muted-foreground: #a0a0a0;
+  --accent: #333333;
+  --accent-foreground: #f0f0f0;
+  --surface-strong: #383838;
+  --destructive: #9a7070;
+  --destructive-foreground: #141414;
+  --border: rgba(255, 255, 255, 0.10);
+  --input: #252525;
+  --ring: #666666;
+  --rating: #b0b0b0;
+  --success: #a0a0a0;
   --font-weight-medium: 500;
   --font-weight-normal: 400;
   --chart-1: #f0e9dd;
@@ -318,18 +318,13 @@ textarea {
 }
 
 :where([class*='bg-card']) {
-  background:
-    radial-gradient(ellipse at 50% 68%, rgba(0, 0, 0, 0.1), transparent 38%),
-    radial-gradient(ellipse at 48% 100%, rgba(255, 255, 255, 0.54), transparent 34%),
-    linear-gradient(180deg, rgba(251, 249, 243, 0.88), rgba(218, 217, 212, 0.72)) !important;
-  border-color: rgba(43, 41, 38, 0.12) !important;
+  background: var(--card) !important;
+  border-color: rgba(43, 41, 38, 0.08) !important;
 }
 
 .dark :where([class*='bg-card']) {
-  background:
-    radial-gradient(ellipse at 50% 64%, rgba(255, 255, 255, 0.08), transparent 42%),
-    linear-gradient(180deg, rgba(30, 28, 25, 0.92), rgba(16, 15, 13, 0.9)) !important;
-  border-color: rgba(246, 241, 232, 0.12) !important;
+  background: var(--card) !important;
+  border-color: rgba(246, 241, 232, 0.08) !important;
 }
 
 
@@ -363,16 +358,8 @@ textarea {
     linear-gradient(180deg, #171614 0%, #11100e 100%);
 }
 
-:where([class*='bg-muted'], [class*='bg-accent'], [class*='bg-secondary']) {
-  background:
-    radial-gradient(ellipse at 50% 65%, rgba(0, 0, 0, 0.055), transparent 48%),
-    linear-gradient(180deg, rgba(235, 231, 222, 0.82), rgba(214, 211, 203, 0.58)) !important;
-}
-
 :where([class*='bg-primary/']) {
-  background:
-    radial-gradient(ellipse at 50% 60%, rgba(0, 0, 0, 0.11), transparent 54%),
-    rgba(43, 41, 38, 0.09) !important;
+  background: rgba(43, 41, 38, 0.09) !important;
 }
 
 :where(button, a, [role='button']) {
@@ -417,11 +404,7 @@ header :where(button, [role='button']) {
 }
 
 .note-detail-scene :where(button, [role='button']) {
-  color: rgba(255, 255, 255, 0.72) !important;
-}
-
-.note-detail-scene :where(button, [role='button']):hover {
-  color: rgba(255, 255, 255, 0.95) !important;
+  color: inherit;
 }
 
 .minimal-fab-exception {
@@ -492,10 +475,7 @@ header :where(button, [role='button']) {
 
 .note-detail-scene {
   isolation: isolate;
-  background:
-    radial-gradient(circle at 80% -8%, rgba(255, 255, 255, 0.18), transparent 25rem),
-    radial-gradient(circle at 10% 22%, rgba(255, 255, 255, 0.055), transparent 18rem),
-    linear-gradient(150deg, #171717 0%, #070707 48%, #010101 100%);
+  background: var(--background);
 }
 
 .note-detail-ambient {
@@ -774,12 +754,351 @@ header :where(button, [role='button']) {
   -webkit-backdrop-filter: blur(18px);
 }
 
+/* ── New Note Detail: nd-* ── */
+
+.nd-scene {
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 75% -5%, rgba(255,255,255,0.12), transparent 22rem),
+    linear-gradient(155deg, #141414 0%, #080808 50%, #020202 100%);
+}
+
+.nd-bg-glow {
+  position: fixed;
+  inset: -10% -20%;
+  height: 50vh;
+  background: radial-gradient(ellipse at 50% 0%, hsl(var(--nd-h, 30), calc(var(--nd-s, 20%) * 0.5), 30%), transparent 65%);
+  filter: blur(40px);
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 0;
+  transition: background 0.8s ease;
+}
+
+/* 카드: 4:5 비율 */
+.nd-card {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  border-radius: 1rem;
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.07) inset,
+    0 24px 64px rgba(0,0,0,0.55),
+    0 4px 16px rgba(0,0,0,0.4);
+}
+
+.nd-card-gloss {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    linear-gradient(135deg, rgba(255,255,255,0.12) 0%, transparent 45%),
+    radial-gradient(ellipse at 30% 10%, rgba(255,255,255,0.09), transparent 55%);
+}
+
+.nd-card-img-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.nd-card-body {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  padding: 1.25rem;
+  background: linear-gradient(
+    to bottom,
+    rgba(0,0,0,0.18) 0%,
+    transparent 30%,
+    transparent 55%,
+    rgba(0,0,0,0.52) 100%
+  );
+}
+
+.nd-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.nd-author-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 9999px;
+  border: 0.5px solid rgba(255,255,255,0.2);
+  background: rgba(0,0,0,0.28);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(255,255,255,0.82);
+  transition: background 0.2s;
+}
+
+.nd-author-chip:hover { background: rgba(0,0,0,0.42); color: #fff; }
+
+.nd-date-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: rgba(255,255,255,0.5);
+  letter-spacing: 0.04em;
+}
+
+.nd-card-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 0;
+}
+
+.nd-tea-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  color: rgba(255,255,255,0.38);
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+}
+
+.nd-tea-name {
+  font-size: clamp(2rem, 10vw, 3.2rem);
+  font-weight: 900;
+  line-height: 0.93;
+  letter-spacing: -0.07em;
+  color: #fff;
+  text-wrap: balance;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-shadow: 0 2px 16px rgba(0,0,0,0.4);
+}
+
+.nd-memo-preview {
+  margin-top: 0.75rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: rgba(255,255,255,0.55);
+  font-style: italic;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.nd-card-bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.nd-tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.nd-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 9999px;
+  border: 0.5px solid rgba(255,255,255,0.18);
+  background: rgba(255,255,255,0.08);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  font-size: 0.66rem;
+  font-weight: 600;
+  color: rgba(255,255,255,0.78);
+  letter-spacing: 0.02em;
+}
+
+.nd-tag-more {
+  background: rgba(255,255,255,0.04);
+  color: rgba(255,255,255,0.38);
+}
+
+.nd-bottom-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.nd-meta-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.nd-meta-line {
+  font-size: 0.68rem;
+  color: rgba(255,255,255,0.5);
+  line-height: 1.4;
+}
+
+.nd-weather { color: rgba(255,255,255,0.42); }
+
+.nd-score-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.nd-brew-dot {
+  display: block;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 9999px;
+  border: 1.5px solid rgba(255,255,255,0.22);
+  box-shadow: 0 0 8px rgba(255,255,255,0.1);
+}
+
+.nd-rating {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: #fff;
+}
+
+.nd-rating-star {
+  width: 0.85rem;
+  height: 0.85rem;
+  fill: #fff;
+  flex-shrink: 0;
+}
+
+.nd-rating strong {
+  font-size: 1.5rem;
+  font-weight: 900;
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.nd-privacy {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: rgba(255,255,255,0.28);
+  text-transform: uppercase;
+}
+
+/* 액션 바 */
+.nd-action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0;
+  margin-top: 0.5rem;
+}
+
+.nd-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0 0.9rem;
+  border-radius: 9999px;
+  border: 0.5px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
+  color: rgba(255,255,255,0.45);
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: background 0.18s, color 0.18s;
+}
+
+.nd-action-btn:hover {
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.85);
+}
+
+.nd-action-btn--active {
+  color: hsl(var(--primary));
+  border-color: hsl(var(--primary) / 0.3);
+  background: hsl(var(--primary) / 0.08);
+}
+
+/* 섹션 */
+.nd-section {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 0.5px solid rgba(255,255,255,0.08);
+}
+
+.nd-section-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  color: rgba(255,255,255,0.28);
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.nd-prose {
+  font-size: 0.92rem;
+  line-height: 1.78;
+  color: rgba(255,255,255,0.78);
+}
+
+.nd-prose p { white-space: pre-wrap; margin: 0.25rem 0; }
+.nd-prose h1 { font-size: 1.1rem; font-weight: 700; margin: 0.75rem 0 0.4rem; }
+.nd-prose h2 { font-size: 1rem; font-weight: 600; margin: 0.6rem 0 0.3rem; }
+.nd-prose ul { list-style: disc; padding-left: 1.25rem; margin: 0.5rem 0; }
+.nd-prose ol { list-style: decimal; padding-left: 1.25rem; margin: 0.5rem 0; }
+.nd-prose code { background: rgba(255,255,255,0.08); border-radius: 0.2rem; padding: 0 0.3rem; font-size: 0.82rem; }
+.nd-prose blockquote { border-left: 2px solid rgba(255,255,255,0.18); padding-left: 0.75rem; color: rgba(255,255,255,0.5); font-style: italic; margin: 0.5rem 0; }
+.nd-prose a { color: #fff; text-decoration: underline; }
+
+.nd-full-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  border: 0.5px solid rgba(255,255,255,0.12);
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: rgba(255,255,255,0.65);
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.nd-full-tag:hover {
+  border-color: rgba(255,255,255,0.28);
+  color: #fff;
+}
+
+.nd-scene :where(button, [role='button']) {
+  color: rgba(255,255,255,0.72) !important;
+}
+
+.nd-scene :where(button, [role='button']):hover {
+  color: rgba(255,255,255,0.95) !important;
+}
+
 @media (max-width: 640px) {
   .note-detail-scene {
-    background:
-      radial-gradient(circle at 84% -8%, rgba(255, 255, 255, 0.2), transparent 20rem),
-      radial-gradient(circle at 6% 28%, rgba(255, 255, 255, 0.052), transparent 15rem),
-      linear-gradient(152deg, #151515 0%, #070707 48%, #010101 100%);
+    background: var(--background);
   }
 
   .note-detail-ambient { height: 26rem; filter: blur(18px); }
@@ -952,23 +1271,11 @@ header :where(button, [role='button']) {
 .note-detail-hero {
   position: relative;
   overflow: hidden;
-  background:
-    radial-gradient(circle at 88% 20%, rgba(255, 255, 255, 0.16), transparent 24%),
-    linear-gradient(154deg, rgba(255, 255, 255, 0.088), rgba(255, 255, 255, 0.026) 58%, rgba(255, 255, 255, 0.06));
+  background: transparent;
 }
 
 .note-detail-hero::before {
-  content: '';
-  position: absolute;
-  right: -4.8rem;
-  top: 2.2rem;
-  width: 12rem;
-  height: 12rem;
-  border-radius: 9999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.1), transparent 62%);
-  opacity: 0.7;
-  animation: note-detail-ripple-pulse 9s ease-in-out infinite;
+  content: none;
 }
 
 .note-detail-privacy-chip,
@@ -1181,10 +1488,10 @@ header :where(button, [role='button']) {
 }
 
 .note-detail-hero {
-  min-height: min(52svh, 26rem);
+  min-height: auto;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: flex-start;
   padding-top: clamp(1rem, 5svh, 2.5rem);
 }
 
@@ -1411,10 +1718,7 @@ header :where(button, [role='button']) {
 
 /* ChaLog detail: geometric graduation-exhibition layer */
 .note-detail-scene {
-  background:
-    radial-gradient(circle at 84% -10%, rgba(255, 255, 255, 0.2), transparent 20rem),
-    conic-gradient(from 210deg at 12% 72%, rgba(255, 255, 255, 0.075), transparent 18%, rgba(255, 255, 255, 0.04) 28%, transparent 42%),
-    linear-gradient(152deg, #121212 0%, #050505 48%, #000 100%);
+  background: var(--background);
 }
 
 .note-detail-geometry-field {
@@ -1842,33 +2146,34 @@ header :where(button, [role='button']) {
 }
 
 .note-detail-hero {
-  min-height: min(56svh, 30rem);
+  min-height: auto;
   padding-bottom: 1.25rem;
 }
 
 .note-detail-tea-title {
-  font-size: clamp(2.2rem, 11vw, 3.65rem);
-  line-height: 0.92;
-  letter-spacing: -0.09em;
+  font-size: clamp(1.6rem, 8vw, 2.4rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
 }
 
 .note-detail-quote blockquote {
-  font-size: clamp(1.35rem, 6.3vw, 2.12rem);
-  line-height: 1.12;
-  letter-spacing: -0.055em;
-  color: rgba(255, 255, 255, 0.94);
+  font-size: clamp(1rem, 4.5vw, 1.4rem);
+  line-height: 1.3;
+  letter-spacing: -0.03em;
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .note-detail-card-deck {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(82%, 1fr);
+  grid-auto-columns: min(88vw, 380px);
   gap: 0.85rem;
   overflow-x: auto;
   overscroll-behavior-x: contain;
   scroll-snap-type: x mandatory;
-  scroll-padding-inline: 0.75rem;
-  padding: 0.35rem 0.75rem 1.15rem;
+  scroll-padding-inline: calc((100% - min(88vw, 380px)) / 2);
+  padding-block: 0.35rem 0.5rem;
+  padding-inline: calc((100% - min(88vw, 380px)) / 2);
   scrollbar-width: none;
 }
 
@@ -1878,18 +2183,15 @@ header :where(button, [role='button']) {
 
 .note-detail-card-deck > * {
   scroll-snap-align: center;
-  min-height: min(82svh, 48rem);
-  max-height: min(82svh, 48rem);
-  overflow-y: hidden;
+  aspect-ratio: 9 / 16;
+  min-height: 0;
+  max-height: none;
+  overflow-y: auto;
   border-radius: 1.45rem !important;
-  background:
-    linear-gradient(145deg, rgba(255,255,255,0.118), rgba(255,255,255,0.044) 56%, rgba(255,255,255,0.032)),
-    rgba(13, 13, 13, 0.78) !important;
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,0.16),
-    0 18px 52px rgba(0,0,0,0.34) !important;
-  backdrop-filter: blur(22px) saturate(1.04);
-  -webkit-backdrop-filter: blur(22px) saturate(1.04);
+  background: var(--card) !important;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.10) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
 }
 
 .note-detail-card-deck > *::before,
@@ -1975,19 +2277,18 @@ header :where(button, [role='button']) {
   }
 
   .note-detail-card-deck > * {
-    min-height: min(82svh, 48rem);
-    max-height: min(82svh, 48rem);
+    aspect-ratio: 9 / 16;
+    min-height: 0;
+    max-height: none;
   }
 }
 
 /* ChaLog detail: first card is the tea title */
 .note-detail-card-deck .note-detail-hero {
-  min-height: min(82svh, 48rem);
-  max-height: min(82svh, 48rem);
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  padding-top: 3rem;
+  justify-content: flex-start;
+  overflow-y: auto;
 }
 
 .note-detail-card-deck .note-detail-hero > .note-detail-enter:first-of-type {
@@ -2327,59 +2628,47 @@ header :where(button, [role='button']) {
 }
 
 .note-detail-card-deck .note-detail-hero {
-  min-height: min(82svh, 48rem);
-  max-height: min(82svh, 48rem);
-  background:
-    radial-gradient(ellipse 120% 80% at 78% 12%, rgba(255, 232, 150, 0.13), transparent 62%),
-    radial-gradient(ellipse 90% 110% at 18% 88%, rgba(180, 210, 255, 0.09), transparent 58%),
-    radial-gradient(ellipse 70% 60% at 50% 50%, rgba(232, 180, 120, 0.07), transparent 72%),
-    linear-gradient(160deg, rgba(255,255,255,0.10), rgba(255,255,255,0.018) 60%, rgba(140,100,40,0.04)),
-    rgba(6, 6, 5, 0.92) !important;
+  min-height: auto;
+  max-height: none;
+  background: var(--background) !important;
 }
 
 .note-detail-card-deck .note-detail-hero::after {
-  content: '' !important;
-  position: absolute;
-  inset: auto -18% -14% -18%;
-  height: 18rem;
-  border-radius: 50%;
-  background: radial-gradient(ellipse at 48% 60%, rgba(232,203,139,0.18), rgba(180,150,80,0.06) 42%, transparent 72%);
-  filter: blur(38px);
-  pointer-events: none;
+  content: none !important;
 }
 
 .note-detail-exhibition-label,
 .note-detail-primary-memo > p,
 .note-detail-story-card > div:first-child p,
 .note-detail-profile-card p[class*='tracking'] {
-  color: rgba(232, 203, 139, 0.58) !important;
-  letter-spacing: 0.38em !important;
+  color: var(--muted-foreground) !important;
+  letter-spacing: 0.18em !important;
 }
 
 .note-detail-card-deck .note-detail-hero button,
-.note-detail-card-deck a {
-  color: rgba(255, 250, 235, 0.62) !important;
+.note-detail-card-deck .note-detail-hero a {
+  color: var(--muted-foreground) !important;
 }
 
 .note-detail-tea-title {
-  font-size: clamp(2.55rem, 12.6vw, 4.15rem) !important;
-  font-weight: 820 !important;
-  line-height: 0.88 !important;
-  letter-spacing: -0.11em !important;
+  font-size: clamp(1.5rem, 7vw, 2.2rem) !important;
+  font-weight: 720 !important;
+  line-height: 1.05 !important;
+  letter-spacing: -0.05em !important;
 }
 
 .note-detail-tea-title span {
-  background:
-    linear-gradient(104deg, #fffaf0 0%, #f6e8bd 36%, rgba(255,255,255,0.88) 58%, rgba(194,154,78,0.62) 100%) !important;
-  -webkit-background-clip: text !important;
-  background-clip: text !important;
-  text-shadow: 0 20px 60px rgba(0,0,0,0.5);
+  background: none !important;
+  -webkit-background-clip: unset !important;
+  background-clip: unset !important;
+  color: var(--foreground) !important;
+  text-shadow: none !important;
 }
 
 .note-detail-quote blockquote {
-  color: rgba(255, 250, 235, 0.94) !important;
-  font-weight: 700 !important;
-  text-shadow: 0 18px 48px rgba(0,0,0,0.45);
+  color: var(--foreground) !important;
+  font-weight: 600 !important;
+  text-shadow: none !important;
 }
 
 .note-detail-quote-mark {
@@ -2565,35 +2854,18 @@ header[class*='bg-black/35'] button {
 
 .note-detail-card-deck .note-detail-hero {
   position: relative;
-  min-height: min(82svh, 48rem) !important;
-  max-height: min(82svh, 48rem) !important;
-  background:
-    radial-gradient(ellipse at 48% 61%, rgba(0,0,0,0.62), transparent 34%),
-    radial-gradient(ellipse at 49% 96%, rgba(255,255,255,0.98), transparent 34%),
-    linear-gradient(180deg, #d8d8d5 0%, #cececb 63%, #ededeb 100%) !important;
+  min-height: auto !important;
+  max-height: none !important;
+  background: var(--background) !important;
   overflow: hidden;
 }
 
 .note-detail-card-deck .note-detail-hero::before {
-  content: '';
-  position: absolute;
-  inset: 34% -12% 12%;
-  border-radius: 50%;
-  background: radial-gradient(ellipse at center, rgba(0,0,0,0.82), rgba(0,0,0,0.44) 38%, transparent 68%);
-  filter: blur(28px);
-  opacity: 0.72;
-  pointer-events: none;
+  content: none !important;
 }
 
 .note-detail-card-deck .note-detail-hero::after {
-  content: '' !important;
-  position: absolute;
-  inset: auto -10% -10% !important;
-  height: 16rem !important;
-  border-radius: 50% !important;
-  background: radial-gradient(ellipse at center, rgba(255,255,255,0.96), transparent 64%) !important;
-  filter: blur(18px) !important;
-  opacity: 0.9 !important;
+  content: none !important;
 }
 
 .note-detail-card-deck .note-detail-hero > .note-detail-enter:first-of-type {
@@ -2861,17 +3133,6 @@ header[class*='bg-black/35'] button {
 
 /* ChaLog detail: poster typography system */
 .note-detail-scene {
-  font-family:
-    'Helvetica Neue',
-    'Arial Narrow',
-    'Avenir Next Condensed',
-    'DIN Condensed',
-    'Pretendard',
-    -apple-system,
-    BlinkMacSystemFont,
-    system-ui,
-    sans-serif !important;
-  font-stretch: condensed;
   font-variant-numeric: tabular-nums lining-nums;
 }
 
@@ -3130,8 +3391,8 @@ header[class*='bg-black/35'] h1 {
   display: flex !important;
   flex-direction: column !important;
   justify-content: flex-start !important;
-  gap: clamp(1.35rem, 4.8svh, 2.75rem) !important;
-  padding: 3.2rem 1.2rem 1.8rem !important;
+  gap: 1rem !important;
+  padding: 2.2rem 1rem 1.2rem !important;
   overflow-y: hidden !important;
 }
 
@@ -3155,34 +3416,23 @@ header[class*='bg-black/35'] h1 {
   bottom: auto !important;
   z-index: 5 !important;
   width: min(100%, 23rem) !important;
-  margin: auto 0 0 !important;
-  padding-top: clamp(1.75rem, 8svh, 5.5rem) !important;
+  margin: 0 !important;
+  padding-top: 0 !important;
 }
 
 .note-detail-card-deck .note-detail-hero .note-detail-quote::before {
-  content: '' !important;
-  display: block !important;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: min(10rem, 52vw);
-  height: 4.5rem;
-  border-radius: 999px;
-  background: radial-gradient(ellipse at left, rgba(255,255,255,0.42), transparent 72%);
-  filter: blur(16px);
-  opacity: 0.62;
-  pointer-events: none;
+  content: none !important;
 }
 
 .note-detail-quote blockquote {
   max-width: 100% !important;
-  font-size: clamp(1.2rem, 5.25vw, 1.95rem) !important;
-  line-height: 1.08 !important;
+  font-size: clamp(0.95rem, 4vw, 1.35rem) !important;
+  line-height: 1.3 !important;
 }
 
-.note-detail-tea-title {
-  font-size: clamp(1.18rem, 5.8vw, 2.15rem) !important;
-  line-height: 1.08 !important;
+.note-detail-card-deck .note-detail-hero .note-detail-tea-title {
+  font-size: clamp(1.5rem, 7vw, 2.2rem) !important;
+  line-height: 1.05 !important;
 }
 
 @media (max-width: 380px) {


### PR DESCRIPTION
## Summary
- Align `/note/:id` with the shared white app shell, default header, and bottom/desktop navigation treatment
- Remove the note-detail scoped forced white button color that made shared chrome appear wrong
- Include the existing grayscale UI cleanup changes that were already uncommitted

## Verification
- `git diff --check`
- `npm run build`

## Known test status
- `npm run test:run -- src/pages/__tests__/NoteDetail.test.tsx` still has stale image-gallery expectations for the current `ImageCarousel` implementation (`사진` grid / `Note image` alt expectations).
- A broader targeted run including `BottomNav.test.tsx` also exposes an existing missing `AuthProvider` test wrapper issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 앱 전체의 시각적 디자인을 업데이트했습니다. 배경 색상과 테마 색상이 개선되어 더욱 세련된 외관을 제공합니다.
  * 댓글 목록과 주간 스트릭 섹션에 반투명 배경 효과가 추가되어 시각적 깊이가 향상되었습니다.

* **개선**
  * 노트 상세 페이지의 레이아웃을 재구성하여 정보를 더 명확하게 표시합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FLYLIKEB/ChaLog/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->