### PR TITLE
Improve chadam detail reading controls

### DIFF
--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -93,7 +93,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="post-detail-comment-list flex flex-col">
       <div className="space-y-2">
         {comments.length === 0 && (
           <p className="text-sm text-muted-foreground py-6 text-center">
@@ -103,7 +103,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
         {comments.map((comment) => {
           const isOwner = user?.id === comment.userId;
           return (
-            <div key={comment.id} className="rounded-xl px-0 py-3 border-b border-border/20 last:border-b-0">
+            <div key={comment.id} className="post-detail-comment rounded-xl px-0 py-4 border-b border-border/20 last:border-b-0">
               <div className="flex gap-2.5">
                 {/* 프로필 아바타 */}
                 <CommentAvatar
@@ -123,14 +123,14 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
                     <div className="flex items-center gap-0.5 shrink-0">
                       <button
                         type="button"
-                        className="p-1.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+                        className="post-detail-comment-icon p-1.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
                         aria-label="답글"
                       >
                         <MessageCircle className="w-3.5 h-3.5" />
                       </button>
                       <button
                         type="button"
-                        className="p-1.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+                        className="post-detail-comment-icon p-1.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
                         aria-label="공감"
                       >
                         <ThumbsUp className="w-3.5 h-3.5" />
@@ -140,7 +140,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
                           <DropdownMenuTrigger asChild>
                             <button
                               type="button"
-                              className="p-1.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+                              className="post-detail-comment-icon p-1.5 rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors"
                               aria-label="더보기"
                             >
                               <MoreVertical className="w-3.5 h-3.5" />
@@ -214,11 +214,11 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
         })}
       </div>
 
-      {/* 댓글 입력 - 네비게이션 바 바로 위 고정 */}
+      {/* 댓글 입력 - 글 흐름 안에 배치해 항상 떠 있지 않도록 유지 */}
       {user ? (
         <form
           onSubmit={handleSubmit}
-          className="fixed bottom-[var(--bottom-nav-spacer)] left-0 right-0 bg-background/80 backdrop-blur-md px-4 py-2.5 z-20"
+          className="post-detail-comment-form mt-5 border-t border-border/40 pt-4"
         >
           <div className="flex items-center gap-0 bg-muted/30 rounded-full overflow-hidden pl-3 pr-1">
             {/* 닉네임 라벨 */}
@@ -230,7 +230,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
               type="text"
               value={newContent}
               onChange={(e) => setNewContent(e.target.value)}
-              placeholder="댓글을 입력하세요."
+              placeholder="댓글을 입력하세요..."
               maxLength={1000}
               className="flex-1 h-10 bg-transparent border-0 text-sm text-foreground placeholder:text-muted-foreground/40 focus:outline-none caret-primary"
             />
@@ -241,6 +241,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
               className="shrink-0 p-2 text-primary disabled:text-muted-foreground/20 transition-colors"
               aria-label="댓글 작성"
             >
+              <span className="sr-only">댓글 작성</span>
               {isSubmitting ? (
                 <Loader2 className="w-5 h-5 animate-spin" />
               ) : (

--- a/src/components/__tests__/CommentList.test.tsx
+++ b/src/components/__tests__/CommentList.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, vi, describe, it, expect } from 'vitest';
 import { CommentList } from '../CommentList';
 import { renderWithRouter } from '../../test/renderWithRouter';
 import { useAuth } from '../../contexts/AuthContext';
-import { commentsApi } from '../../lib/api';
+import { authApi, commentsApi } from '../../lib/api';
 import { Comment } from '../../types';
 
 const mockDate = new Date('2025-01-01T00:00:00.000Z');
@@ -28,6 +28,9 @@ vi.mock('../../contexts/AuthContext', async () => {
 });
 
 vi.mock('../../lib/api', () => ({
+  authApi: {
+    getMe: vi.fn().mockRejectedValue(new Error('unauthenticated')),
+  },
   commentsApi: {
     create: vi.fn(),
     update: vi.fn(),
@@ -44,6 +47,7 @@ describe('CommentList 컴포넌트', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authApi.getMe).mockRejectedValue(new Error('unauthenticated'));
     vi.mocked(useAuth).mockReturnValue({
       user: mockUser,
       isAuthenticated: true,
@@ -140,15 +144,15 @@ describe('CommentList 컴포넌트', () => {
     renderWithRouter(
       <CommentList postId={1} comments={[myComment]} onCommentsChange={onCommentsChange} />,
     );
-    expect(screen.getByLabelText('댓글 수정')).toBeInTheDocument();
-    expect(screen.getByLabelText('댓글 삭제')).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByLabelText('더보기'));
+    expect(screen.getByText('수정')).toBeInTheDocument();
+    expect(screen.getByText('삭제')).toBeInTheDocument();
   });
 
   it('타인 댓글에 수정/삭제 버튼을 표시하지 않는다', () => {
     renderWithRouter(
       <CommentList postId={1} comments={mockComments} onCommentsChange={onCommentsChange} />,
     );
-    expect(screen.queryByLabelText('댓글 수정')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('댓글 삭제')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('더보기')).not.toBeInTheDocument();
   });
 });

--- a/src/contexts/PullToRefreshContext.tsx
+++ b/src/contexts/PullToRefreshContext.tsx
@@ -70,6 +70,7 @@ export function PullToRefreshProvider({ children }: { children: React.ReactNode 
   }, [location.pathname]);
 
   const showIndicator = !isPullDisabled && (pullDistance > 0 || isRefreshing);
+  const shouldRenderBottomNavSpacer = !/^\/chadam\/\d+$/.test(location.pathname);
 
   return (
     <PullToRefreshContext.Provider value={registerRefresh}>
@@ -137,7 +138,7 @@ export function PullToRefreshProvider({ children }: { children: React.ReactNode 
             ))}
           </div>
         {children}
-        <BottomNavSpacer />
+        {shouldRenderBottomNavSpacer && <BottomNavSpacer />}
         </div>
       </div>
     </PullToRefreshContext.Provider>

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -31,7 +31,6 @@ const CATEGORY_TO_BOARD: Record<PostCategory, string> = {
 };
 import { postsApi, commentsApi } from '../lib/api';
 import { Header } from '../components/Header';
-import { BottomNav } from '../components/BottomNav';
 import { ImageCarousel } from '../components/ImageCarousel';
 import { CommentList } from '../components/CommentList';
 import { PostReportModal } from '../components/PostReportModal';
@@ -62,6 +61,9 @@ export function PostDetail() {
   const [isTogglingLike, setIsTogglingLike] = useState(false);
   const [isTogglingBookmark, setIsTogglingBookmark] = useState(false);
   const [reportModalOpen, setReportModalOpen] = useState(false);
+  const [readingProgress, setReadingProgress] = useState(0);
+  const articleRef = useRef<HTMLDivElement | null>(null);
+  const commentsSectionRef = useRef<HTMLDivElement | null>(null);
   const { share } = useShare();
 
   const fetchData = useCallback(async () => {
@@ -92,6 +94,61 @@ export function PostDetail() {
     }
     fetchData();
   }, [postId, navigate, fetchData]);
+
+  useEffect(() => {
+    const scrollRoot = articleRef.current?.closest('.overflow-y-auto') as HTMLElement | null;
+
+    const updateReadingProgress = () => {
+      const article = articleRef.current;
+      if (!article) {
+        setReadingProgress(0);
+        return;
+      }
+
+      if (scrollRoot && scrollRoot.scrollTop + scrollRoot.clientHeight >= scrollRoot.scrollHeight - 2) {
+        setReadingProgress(100);
+        return;
+      }
+
+      const rootRect = scrollRoot?.getBoundingClientRect();
+      const articleRect = article.getBoundingClientRect();
+      const dockHeight = document.querySelector<HTMLElement>('.post-detail-reading-dock')?.offsetHeight ?? 0;
+      const viewportBottom = rootRect
+        ? rootRect.bottom - dockHeight
+        : window.innerHeight - dockHeight;
+      const readableDistance = Math.max(1, articleRect.height);
+      const progress = ((viewportBottom - articleRect.top) / readableDistance) * 100;
+
+      setReadingProgress(Math.min(100, Math.max(0, progress)));
+    };
+
+    const previousOverscrollBehaviorY = scrollRoot?.style.overscrollBehaviorY;
+    const previousScrollPaddingBottom = scrollRoot?.style.scrollPaddingBottom;
+
+    if (scrollRoot) {
+      scrollRoot.style.overscrollBehaviorY = 'none';
+      scrollRoot.style.scrollPaddingBottom = '3.5rem';
+    }
+
+    updateReadingProgress();
+    scrollRoot?.addEventListener('scroll', updateReadingProgress, { passive: true });
+    window.addEventListener('scroll', updateReadingProgress, { passive: true });
+    window.addEventListener('resize', updateReadingProgress);
+
+    return () => {
+      if (scrollRoot) {
+        scrollRoot.style.overscrollBehaviorY = previousOverscrollBehaviorY ?? '';
+        scrollRoot.style.scrollPaddingBottom = previousScrollPaddingBottom ?? '';
+      }
+      scrollRoot?.removeEventListener('scroll', updateReadingProgress);
+      window.removeEventListener('scroll', updateReadingProgress);
+      window.removeEventListener('resize', updateReadingProgress);
+    };
+  }, [post, comments.length]);
+
+  const handleScrollToComments = () => {
+    commentsSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
 
   const handleToggleLike = async () => {
     if (!user) { toast.error('로그인이 필요합니다.'); return; }
@@ -141,11 +198,11 @@ export function PostDetail() {
   const authorImage = post.isAnonymous ? null : post.user?.profileImageUrl;
 
   return (
-    <div className="post-detail-page min-h-screen pb-32">
+    <div className="post-detail-page min-h-screen">
       <Header showBack title={CATEGORY_TO_BOARD[post.category] ?? '차담'} showProfile />
 
       {/* 게시글 영역 */}
-      <div className="px-5 pt-4 pb-3">
+      <div ref={articleRef} className="post-detail-paper px-5 pt-4 pb-3">
         {/* 작성자 */}
         <div className="flex items-center gap-2.5 mb-4">
           {authorImage ? (
@@ -196,7 +253,7 @@ export function PostDetail() {
 
         {/* 제목 */}
         {post.title && (
-          <h1 className="text-lg font-bold text-foreground leading-snug mb-3">{post.title}</h1>
+          <h1 className="post-detail-title text-lg font-bold text-foreground leading-snug mb-3">{post.title}</h1>
         )}
 
         {/* 본문 */}
@@ -230,10 +287,14 @@ export function PostDetail() {
               {likeCount > 0 && <span className="font-medium">{likeCount}</span>}
             </button>
 
-            <span className="flex items-center gap-1 text-sm text-muted-foreground">
+            <button
+              type="button"
+              onClick={handleScrollToComments}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
               <MessageCircle className="w-[18px] h-[18px]" />
               {comments.length > 0 && <span className="font-medium">{comments.length}</span>}
-            </span>
+            </button>
 
             <button
               onClick={handleToggleBookmark}
@@ -289,7 +350,7 @@ export function PostDetail() {
       <div className="h-2 bg-muted/60 dark:bg-muted/30" />
 
       {/* 댓글 영역 */}
-      <div className="px-5 pt-4">
+      <div ref={commentsSectionRef} className="post-detail-comments px-5 pt-4">
         {/* 태그된 차록 */}
         {post.taggedNotes && post.taggedNotes.length > 0 && (
           <div className="flex flex-col gap-2 mb-4">
@@ -346,7 +407,58 @@ export function PostDetail() {
         postId={postId}
       />
 
-      <BottomNav />
+      <nav className="post-detail-reading-dock" aria-label="글 상세 액션">
+        <div className="post-detail-reading-progress" aria-hidden>
+          <span style={{ width: `${readingProgress}%` }} />
+        </div>
+        <div className="post-detail-reading-actions">
+          <button
+            type="button"
+            onClick={handleToggleLike}
+            disabled={isTogglingLike}
+            className={cn('post-detail-reading-action', isLiked && 'is-active')}
+            aria-label="좋아요"
+          >
+            {isTogglingLike ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <Heart className={cn('w-5 h-5', isLiked && 'fill-current')} />
+            )}
+            <span>{likeCount}</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleScrollToComments}
+            className="post-detail-reading-action post-detail-comment-jump"
+            aria-label="댓글로 이동"
+          >
+            <MessageCircle className="w-5 h-5" />
+            <span>{comments.length}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => share(post?.title ?? '게시글', window.location.href)}
+            className="post-detail-reading-action"
+            aria-label="공유"
+          >
+            <Share2 className="w-5 h-5" />
+          </button>
+          <button
+            type="button"
+            onClick={handleToggleBookmark}
+            disabled={isTogglingBookmark}
+            className={cn('post-detail-reading-action', isBookmarked && 'is-active')}
+            aria-label="스크랩"
+          >
+            {isTogglingBookmark ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <Bookmark className={cn('w-5 h-5', isBookmarked && 'fill-current')} />
+            )}
+          </button>
+        </div>
+      </nav>
+
     </div>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1145,7 +1145,7 @@ header :where(button, [role='button']) {
   justify-content: center;
   gap: 0.4rem;
   min-width: 2.75rem;
-  min-height: 2.75rem;
+  min-height: 2.45rem;
   padding: 0 0.9rem;
   border-radius: 9999px;
   border: 0.5px solid rgba(255,255,255,0.1);
@@ -3823,4 +3823,174 @@ header[class*='bg-black/35'] h1 {
     BlinkMacSystemFont,
     system-ui,
     sans-serif !important;
+}
+
+/* Chadam post detail: Brunch-like reading surface. */
+.post-detail-page {
+  background: #fff;
+}
+
+.post-detail-paper,
+.post-detail-comments {
+  max-width: 720px;
+  margin-inline: auto;
+  background: #fff;
+}
+
+.post-detail-title {
+  font-weight: 650;
+  letter-spacing: -0.035em;
+}
+
+.post-detail-content {
+  color: #333;
+  font-size: clamp(1.05rem, 4.2vw, 1.28rem) !important;
+  font-weight: 350;
+  letter-spacing: -0.045em;
+  line-height: 2.05 !important;
+  word-break: keep-all;
+}
+
+.post-detail-content :where(p, li, blockquote) {
+  margin-block: 1.05em;
+}
+
+.post-detail-comments {
+  scroll-margin-top: var(--header-spacer);
+  scroll-margin-bottom: 3.5rem;
+  padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0px));
+}
+
+.post-detail-comment-list {
+  padding-bottom: 0.5rem;
+}
+
+.post-detail-comment {
+  border-color: rgba(0, 0, 0, 0.08) !important;
+}
+
+.post-detail-comment-icon {
+  color: rgba(26, 26, 26, 0.34) !important;
+}
+
+.post-detail-comment-icon:hover {
+  color: rgba(26, 26, 26, 0.68) !important;
+}
+
+.post-detail-comment-form {
+  position: static;
+  background: transparent;
+}
+
+.post-detail-reading-dock {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 55;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(255, 255, 255, 0.96);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+}
+
+.post-detail-reading-progress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -2px;
+  height: 2px;
+  background: rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.post-detail-reading-progress span {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: #1f1f1f;
+  transition: width 120ms linear;
+}
+
+.post-detail-reading-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  max-width: 720px;
+  min-height: 3.35rem;
+  margin-inline: auto;
+  padding: 0.35rem 1.25rem;
+}
+
+.post-detail-reading-action {
+  display: inline-flex;
+  min-width: 3rem;
+  min-height: 2.45rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  color: #777;
+  font-size: 0.95rem;
+  font-weight: 450;
+  transition: color 160ms ease;
+}
+
+.post-detail-reading-action:hover,
+.post-detail-reading-action.is-active {
+  color: #1f1f1f;
+}
+
+.post-detail-comment-jump {
+  color: #1f1f1f;
+}
+
+.dark .post-detail-page {
+  background: #181818;
+}
+
+.dark .post-detail-paper,
+.dark .post-detail-comments {
+  background: #181818;
+}
+
+.dark .post-detail-content {
+  color: #e7e7e7;
+}
+
+.dark .post-detail-reading-dock {
+  border-top-color: rgba(255, 255, 255, 0.10);
+  background: rgba(20, 20, 20, 0.96);
+}
+
+.dark .post-detail-reading-progress {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.dark .post-detail-reading-progress span {
+  background: #f2f2f2;
+}
+
+.dark .post-detail-reading-action {
+  color: #aaa;
+}
+
+.dark .post-detail-reading-action:hover,
+.dark .post-detail-reading-action.is-active,
+.dark .post-detail-comment-jump {
+  color: #f2f2f2;
+}
+
+@media (min-width: 768px) {
+  .post-detail-page {
+    padding-bottom: 4rem !important;
+  }
+
+  .post-detail-comments {
+    padding-bottom: 4rem;
+  }
+
+  .post-detail-reading-dock {
+    bottom: 0;
+    left: 172px;
+  }
 }


### PR DESCRIPTION
## Summary
- Restyle Chadam post detail typography and comment presentation around Pretendard/Brunch-like reading
- Replace shared bottom nav on post detail with a post-specific reading action bar and progress line
- Keep comment composer reachable by binding progress/spacing to the actual pull-to-refresh scroll container

## Verification
- npm test -- --run src/pages/__tests__/PostDetail.test.tsx src/components/__tests__/CommentList.test.tsx
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 글 읽기 진행률 표시 기능 추가
  * 댓글 영역으로의 빠른 이동 버튼 추가

* **개선 사항**
  * 글 상세 페이지의 동작 버튼들을 하단 고정 영역으로 재배치
  * 댓글 입력 폼 레이아웃을 문서 흐름 기반으로 변경
  * 접근성 개선 (화면 읽기 전용 라벨 추가)
  * 전반적인 스타일 및 간격 조정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FLYLIKEB/ChaLog/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->