### PR TITLE
Tighten shared header chrome

### DIFF
--- a/src/components/ChaLogLogo.tsx
+++ b/src/components/ChaLogLogo.tsx
@@ -7,22 +7,24 @@ interface ChaLogLogoProps {
   /** 아이콘만 표시 (제목과 함께 쓸 때) */
   iconOnly?: boolean;
   className?: string;
+  size?: 'default' | 'compact';
   /** 클릭 시 홈으로 이동하는 버튼으로 렌더 */
   asButton?: boolean;
   onClick?: () => void;
 }
 
 /** 차멍 로고 - 먹색 단색 기하 패턴 마크. 한국어권: 차멍, 영어권: ChaMeong */
-export function ChaLogLogo({ iconOnly = false, className, asButton, onClick }: ChaLogLogoProps) {
+export function ChaLogLogo({ iconOnly = false, className, size = 'default', asButton, onClick }: ChaLogLogoProps) {
   const isKorean = useIsKorean();
+  const isCompact = size === 'compact';
 
   const content = (
     <>
-      <div className="flex items-center justify-center shrink-0 w-11 h-11 text-primary">
-        <BrandMark className="w-11 h-11" />
+      <div className={cn('flex items-center justify-center shrink-0 text-primary', isCompact ? 'w-9 h-9' : 'w-11 h-11')}>
+        <BrandMark className={isCompact ? 'w-9 h-9' : 'w-11 h-11'} />
       </div>
       {!iconOnly && (
-        <span className="font-['Nanum_Myeongjo'] font-bold tracking-[-0.04em] text-2xl text-foreground pt-0.5">
+        <span className={cn("font-['Nanum_Myeongjo'] font-bold tracking-[-0.04em] text-foreground pt-0.5", isCompact ? 'text-xl' : 'text-2xl')}>
           {isKorean ? '차멍' : 'ChaMeong'}
         </span>
       )}
@@ -30,7 +32,8 @@ export function ChaLogLogo({ iconOnly = false, className, asButton, onClick }: C
   );
 
   const wrapperClass = cn(
-    'flex items-center gap-0.5 min-h-[48px] transition-colors',
+    'flex items-center gap-0.5 transition-colors',
+    isCompact ? 'min-h-[40px]' : 'min-h-[48px]',
     (asButton || onClick) && 'hover:opacity-80 cursor-pointer rounded-none px-1 -ml-1',
     className,
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,7 +28,7 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
   return (
     <>
       <header
-        className={`fixed top-0 left-0 right-0 md:left-[160px] z-100 py-3 pt-[calc(0.75rem+env(safe-area-inset-top,0px))] ${
+        className={`fixed top-0 left-0 right-0 md:left-[160px] z-100 py-2 pt-[calc(0.5rem+env(safe-area-inset-top,0px))] ${
           isGlassDark
             ? 'bg-neutral-950 text-white'
             : 'bg-background text-foreground'
@@ -39,12 +39,12 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
             {showBack && (
               <button
                 onClick={() => (onBack ? onBack() : navigate(-1))}
-                className={`shrink-0 min-h-[44px] min-w-[44px] p-2.5 -ml-1 rounded-none transition-colors flex items-center justify-center ${
+                className={`shrink-0 min-h-9 min-w-9 p-2 -ml-1 rounded-none transition-colors flex items-center justify-center ${
                   isGlassDark ? 'text-white/80 hover:text-white' : 'text-foreground hover:text-foreground/70'
                 }`}
                 aria-label="뒤로"
               >
-                <ChevronLeft className="w-5 h-5" />
+                <ChevronLeft className="w-4.5 h-4.5" />
               </button>
             )}
             {(showLogo || (!title && !showBack) || showBack) && (
@@ -52,11 +52,12 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
                 iconOnly={!!title}
                 asButton
                 onClick={() => navigate('/')}
+                size="compact"
               />
             )}
             {title && (
               <h1
-                className={`font-['Nanum_Myeongjo'] font-bold text-2xl tracking-[-0.04em] truncate min-w-0 pt-0.5 ${
+                className={`font-['Nanum_Myeongjo'] font-bold text-xl tracking-[-0.04em] truncate min-w-0 pt-0.5 ${
                   isGlassDark ? 'text-white/90' : 'text-foreground'
                 }`}
               >
@@ -67,24 +68,24 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
           <div className="flex items-center gap-1 shrink-0">
             <button
               onClick={() => navigate('/sasaek')}
-              className={`min-h-[44px] min-w-[44px] p-2.5 rounded-none transition-colors flex items-center justify-center ${
+              className={`min-h-9 min-w-9 p-2 rounded-none transition-colors flex items-center justify-center ${
                 isGlassDark ? 'text-white/75 hover:text-white' : 'hover:text-foreground/70'
               }`}
               aria-label="탐색"
             >
-              <Search className="w-5 h-5" />
+              <Search className="w-4.5 h-4.5" />
             </button>
             {isAuthenticated && (
               <button
                 onClick={() => navigate('/notifications')}
-                className={`relative min-h-[44px] min-w-[44px] p-2.5 rounded-none transition-colors flex items-center justify-center ${
+                className={`relative min-h-9 min-w-9 p-2 rounded-none transition-colors flex items-center justify-center ${
                   isGlassDark ? 'text-white/75 hover:text-white' : 'hover:text-foreground/70'
                 }`}
                 aria-label="알림"
               >
-                <Bell className="w-5 h-5" />
+                <Bell className="w-4.5 h-4.5" />
                 {unreadCount > 0 && (
-                  <span className="absolute top-1.5 right-1.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-primary text-primary-foreground text-[10px] font-bold leading-none">
+                  <span className="absolute top-1 right-1 flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold leading-none">
                     {unreadCount > 99 ? '99+' : unreadCount}
                   </span>
                 )}
@@ -93,11 +94,11 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
             {showProfile && (
               <button
                 onClick={() => navigate(isAuthenticated ? '/settings' : '/login')}
-                className={`min-h-[44px] min-w-[44px] p-2.5 rounded-none transition-colors flex items-center justify-center ${
+                className={`min-h-9 min-w-9 p-2 rounded-none transition-colors flex items-center justify-center ${
                   isGlassDark ? 'text-white/75 hover:text-white' : 'hover:text-foreground/70'
                 }`}
               >
-                <User className="w-5 h-5" />
+                <User className="w-4.5 h-4.5" />
               </button>
             )}
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --header-spacer: calc(4.25rem + env(safe-area-inset-top, 0px));
+  --header-spacer: calc(3.25rem + env(safe-area-inset-top, 0px));
   --bottom-nav-spacer: calc(5rem + env(safe-area-inset-bottom, 0px));
   --font-size: 16px;
   /* 카드 공통 */


### PR DESCRIPTION
## Summary
- Shorten the shared fixed Header height across the app
- Add compact logo sizing for Header usage
- Reduce common header back/search/bell/profile icon touch targets and visual icon sizes proportionally
- Keep --header-spacer aligned with the new shorter header

## Verification
- npm test -- --run src/pages/__tests__/PostDetail.test.tsx
- npm run build

Note: src/components/__tests__/BottomNav.test.tsx currently fails independently because it renders BottomNav without AuthProvider.