### PR TITLE
Refine sticky header and add-button branding

### DIFF
--- a/src/components/AddLogoIcon.tsx
+++ b/src/components/AddLogoIcon.tsx
@@ -1,0 +1,12 @@
+import { BrandMark } from './BrandMark';
+import { cn } from './ui/utils';
+
+type AddLogoIconProps = {
+  className?: string;
+  title?: string;
+};
+
+/** Shared logo-shaped replacement for add/plus affordances. */
+export function AddLogoIcon({ className, title }: AddLogoIconProps) {
+  return <BrandMark title={title} className={cn('shrink-0', className)} />;
+}

--- a/src/components/AddTemplateModal.tsx
+++ b/src/components/AddTemplateModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Plus, Trash2, Loader2 } from 'lucide-react';
+import { Trash2, Loader2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -15,6 +15,7 @@ import { notesApi, CreateRatingSchemaRequest } from '../lib/api';
 import { RatingSchema } from '../types';
 import { toast } from 'sonner';
 import { logger } from '../lib/logger';
+import { AddLogoIcon } from './AddLogoIcon';
 
 interface AxisInput {
   nameKo: string;
@@ -177,7 +178,7 @@ export function AddTemplateModal({
                 onClick={addAxis}
                 className="h-8 px-2"
               >
-                <Plus className="w-4 h-4 mr-1" />
+                <AddLogoIcon className="w-4 h-4 mr-1" />
                 추가
               </Button>
             </div>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,17 +1,20 @@
-import { HTMLAttributes } from 'react';
+import type { ComponentType, HTMLAttributes, SVGProps } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Home, MessageSquare, Package } from 'lucide-react';
 import { cn } from './ui/utils';
 import { useAuth } from '../contexts/AuthContext';
 import { ChaLogLogo } from './ChaLogLogo';
+import { LIQUID_GLASS } from '../constants/liquidGlass';
 
 type NavItemDef = {
   label: string;
   path: string;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
   activeStyle?: 'fill' | 'bold';
   isActive?: (pathname: string) => boolean;
 };
+
+type NavDirection = 'horizontal' | 'vertical';
 
 const NAV_ITEMS: NavItemDef[] = [
   { label: '홈', path: '/', icon: Home, activeStyle: 'fill' },
@@ -31,6 +34,22 @@ const NAV_ITEMS: NavItemDef[] = [
   },
 ];
 
+const MOBILE_BOTTOM_NAV_CLASS = cn(
+  'app-bottom-nav app-bottom-nav-mobile fixed left-6 right-6 z-60 rounded-[1.5rem] px-1.5 py-1',
+  'bottom-[calc(0.75rem+env(safe-area-inset-bottom,0px))] flex items-center justify-around md:hidden',
+  LIQUID_GLASS.surface,
+);
+
+function navItemClass(direction: NavDirection, isActive: boolean) {
+  return cn(
+    'flex items-center justify-center gap-1 transition-colors duration-200',
+    direction === 'horizontal'
+      ? 'min-h-[40px] min-w-[44px] flex-col rounded-xl px-0.5'
+      : 'min-h-[40px] w-full px-3 py-2 rounded-none flex-row gap-3',
+    isActive ? 'text-primary' : 'text-muted-foreground',
+  );
+}
+
 function NavButton({
   item,
   pathname,
@@ -40,7 +59,7 @@ function NavButton({
   item: NavItemDef;
   pathname: string;
   onClick: () => void;
-  direction: 'horizontal' | 'vertical';
+  direction: NavDirection;
 }) {
   const isActive = item.isActive ? item.isActive(pathname) : pathname === item.path;
   const Icon = item.icon;
@@ -52,13 +71,7 @@ function NavButton({
   return (
     <button
       onClick={onClick}
-      className={cn(
-        'flex items-center justify-center gap-1 transition-colors duration-200',
-        direction === 'horizontal'
-          ? 'min-h-[40px] min-w-[44px] flex-col rounded-xl px-0.5'
-          : 'min-h-[40px] w-full px-3 py-2 rounded-none flex-row gap-3',
-        isActive ? 'text-primary' : 'text-muted-foreground',
-      )}
+      className={navItemClass(direction, isActive)}
       aria-label={item.label}
     >
       <div className="w-5 h-5 flex items-center justify-center">
@@ -86,7 +99,7 @@ function ProfileButton({
 }: {
   pathname: string;
   onClick: () => void;
-  direction: 'horizontal' | 'vertical';
+  direction: NavDirection;
 }) {
   const { user } = useAuth();
   const isActive = pathname === '/my-notes' || pathname.startsWith('/user/');
@@ -94,13 +107,7 @@ function ProfileButton({
   return (
     <button
       onClick={onClick}
-      className={cn(
-        'flex items-center justify-center gap-1 transition-colors duration-200',
-        direction === 'horizontal'
-          ? 'min-h-[40px] min-w-[44px] flex-col rounded-xl px-0.5'
-          : 'min-h-[40px] w-full px-3 py-2 rounded-none flex-row gap-3',
-        isActive ? 'text-primary' : 'text-muted-foreground',
-      )}
+      className={navItemClass(direction, isActive)}
       aria-label="내 차록"
     >
       <div className="w-6 h-6 rounded-full overflow-hidden">
@@ -140,13 +147,7 @@ export function BottomNav({ className, ...rest }: BottomNavProps) {
     <>
       {/* Mobile: horizontal bottom bar */}
       <nav
-        className={cn(
-          'app-bottom-nav app-bottom-nav-mobile fixed left-6 right-6 z-60 overflow-hidden isolate border border-white/35 rounded-[1.5rem] shadow-[0_14px_34px_rgba(0,0,0,0.16)] px-1.5 py-1',
-          'bottom-[calc(0.75rem+env(safe-area-inset-bottom,0px))]',
-          'flex items-center justify-around',
-          'md:hidden',
-          className,
-        )}
+        className={cn(MOBILE_BOTTOM_NAV_CLASS, className)}
         {...rest}
       >
         {NAV_ITEMS.map((item) => (

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode } from 'react';
 import { cn } from './ui/utils';
+import { AddLogoIcon } from './AddLogoIcon';
+import { LIQUID_GLASS } from '../constants/liquidGlass';
 
 type FloatingActionButtonProps = {
   onClick?: () => void;
@@ -27,7 +29,9 @@ export function FloatingActionButton({
       aria-label={ariaLabel}
       onClick={onClick}
       className={cn(
-        'minimal-fab-exception fixed right-6 z-50 w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-[0_2px_12px_rgba(43,41,38,0.22)] flex items-center justify-center transition-colors hover:bg-primary/90 focus-visible:outline-none',
+        'minimal-fab-exception pointer-events-auto fixed right-6 z-[70] flex h-14 w-14 items-center justify-center rounded-full text-primary shadow-[0_10px_28px_rgba(43,41,38,0.22)] transition-transform hover:scale-[1.03] focus-visible:outline-none',
+        LIQUID_GLASS.surface,
+        LIQUID_GLASS.fab,
         positionClasses[position],
         className
       )}
@@ -35,7 +39,7 @@ export function FloatingActionButton({
         bottom: 'calc(var(--bottom-nav-spacer) + 0.75rem)',
       } : undefined}
     >
-      {children}
+      {children ?? <AddLogoIcon className="h-8 w-8" />}
     </button>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { User, ChevronLeft, Bell, Search } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
@@ -19,66 +20,173 @@ interface HeaderProps {
 }
 
 const HEADER_SHELL_CLASS = cn(
-  'fixed top-[calc(0.35rem+env(safe-area-inset-top,0px))] left-4 right-4 md:left-[176px] md:right-4',
-  'z-100 rounded-[1.5rem] py-1.5',
+  'fixed top-[calc(0.35rem+env(safe-area-inset-top,0px))]',
+  'left-1/2 -translate-x-1/2 md:left-[calc(50%+86px)]',
+  'z-100 py-1 transition-[width,border-radius,box-shadow,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width,border-radius,box-shadow,opacity]',
   LIQUID_GLASS.surface,
 );
 
-const HEADER_CONTENT_CLASS = 'max-w-2xl md:max-w-5xl lg:max-w-6xl mx-auto flex items-center justify-between px-3 sm:px-5';
+const HEADER_CONTENT_CLASS = 'max-w-2xl md:max-w-5xl lg:max-w-6xl mx-auto relative flex items-center px-3 transition-[height] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] sm:px-5';
 const HEADER_ICON_CLASS = 'w-4.5 h-4.5';
+const HEADER_SIDE_CLASS = 'absolute inset-y-0 flex items-center';
 
 function headerIconButtonClass(isGlassDark: boolean, className?: string) {
   return cn(
-    'min-h-9 min-w-9 p-2 rounded-full transition-colors flex items-center justify-center',
+    'h-10 w-10 p-2 rounded-full transition-colors flex items-center justify-center',
     isGlassDark ? 'text-white/75 hover:text-white' : 'text-foreground hover:text-foreground/70',
     className,
   );
 }
 
 export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 'default' }: HeaderProps) {
+  const headerRef = useRef<HTMLElement | null>(null);
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
   const unreadCount = useNotificationCount();
+  const [scrollState, setScrollState] = useState({ isScrolled: false, isScrollingDown: false });
 
   const headerHeight = 'var(--header-spacer)';
   const isGlassDark = tone === 'glassDark';
+  const isCollapsed = scrollState.isScrollingDown;
+
+  useEffect(() => {
+    const scrollRoot = headerRef.current?.closest('main') ?? window;
+    let previousTop = scrollRoot instanceof Window ? scrollRoot.scrollY : scrollRoot.scrollTop;
+    let downDistance = 0;
+    let upDistance = 0;
+    let isCollapsed = false;
+    let frame = 0;
+
+    const updateScrollState = () => {
+      const currentTop = scrollRoot instanceof Window ? scrollRoot.scrollY : scrollRoot.scrollTop;
+      const delta = currentTop - previousTop;
+      const isScrolled = currentTop > 12;
+
+      if (currentTop < 24) {
+        downDistance = 0;
+        upDistance = 0;
+        isCollapsed = false;
+      } else if (delta > 2) {
+        downDistance += delta;
+        upDistance = 0;
+        if (currentTop > 96 && downDistance > 36) {
+          isCollapsed = true;
+          downDistance = 0;
+        }
+      } else if (delta < -2) {
+        upDistance += Math.abs(delta);
+        downDistance = 0;
+        if (upDistance > 56) {
+          isCollapsed = false;
+          upDistance = 0;
+        }
+      }
+
+      const nextState = {
+        isScrolled,
+        isScrollingDown: isCollapsed,
+      };
+
+      previousTop = currentTop;
+      setScrollState((prev) =>
+        prev.isScrolled === nextState.isScrolled && prev.isScrollingDown === nextState.isScrollingDown
+          ? prev
+          : nextState,
+      );
+    };
+
+    const handleScroll = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        updateScrollState();
+      });
+    };
+
+    updateScrollState();
+    scrollRoot.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      scrollRoot.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   return (
     <>
       <header
-        className={cn(HEADER_SHELL_CLASS, isGlassDark ? 'text-white' : 'text-foreground')}
+        ref={headerRef}
+        className={cn(
+          HEADER_SHELL_CLASS,
+          isGlassDark ? 'text-white' : 'text-foreground',
+          isCollapsed
+            ? 'w-[4.25rem] rounded-full opacity-100 shadow-[0_18px_52px_rgba(0,0,0,0.18)]'
+            : cn(
+                'w-[calc(100%-2rem)] rounded-[1.5rem] opacity-100 md:w-[calc(100%-12rem)]',
+                scrollState.isScrolled && 'rounded-[1.25rem] shadow-[0_16px_46px_rgba(0,0,0,0.16)]',
+              ),
+        )}
       >
-        <div className={HEADER_CONTENT_CLASS}>
-          <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div className={cn(HEADER_CONTENT_CLASS, isCollapsed ? 'h-10' : scrollState.isScrolled ? 'h-12' : 'h-12', isCollapsed && 'px-0 sm:px-0')}>
+          <div
+            className={cn(
+              HEADER_SIDE_CLASS,
+              'left-3 justify-start transition-all duration-400 ease-[cubic-bezier(0.22,1,0.36,1)] sm:left-5',
+              isCollapsed && 'pointer-events-none -translate-x-2 opacity-0',
+            )}
+          >
             {showBack && (
               <button
                 onClick={() => (onBack ? onBack() : navigate(-1))}
-                className={headerIconButtonClass(isGlassDark, 'shrink-0 -ml-1')}
+                className={headerIconButtonClass(isGlassDark, '-ml-2')}
                 aria-label="뒤로"
               >
                 <ChevronLeft className={HEADER_ICON_CLASS} />
               </button>
             )}
-            {(showLogo || (!title && !showBack) || showBack) && (
+          </div>
+
+          <div className={cn(
+            'absolute inset-y-0 left-1/2 flex min-w-0 -translate-x-1/2 items-center justify-center text-center transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]',
+            isCollapsed ? 'px-0' : 'px-12',
+          )}>
+            {isCollapsed ? (
               <ChaLogLogo
-                iconOnly={!!title}
+                iconOnly
                 asButton
                 onClick={() => navigate('/')}
                 size="compact"
+                className="ml-0 px-0"
               />
-            )}
-            {title && (
+            ) : showLogo || (!title && !showBack) ? (
+              <button
+                type="button"
+                onClick={() => navigate('/')}
+                className="flex flex-col items-center justify-center rounded-full px-0 transition-opacity hover:opacity-80"
+                aria-label="차멍 홈으로"
+              >
+                <ChaLogLogo iconOnly size="compact" className="ml-0 min-h-0 px-0" />
+                <span className="-mt-1 font-['Nanum_Myeongjo'] text-[10px] font-bold leading-none tracking-[-0.04em]">차멍</span>
+              </button>
+            ) : title ? (
               <h1
                 className={cn(
-                  "font-['Nanum_Myeongjo'] font-bold text-xl tracking-[-0.04em] truncate min-w-0 pt-0.5",
+                  "min-w-0 truncate pt-0.5 font-['Nanum_Myeongjo'] text-xl font-bold tracking-[-0.04em]",
                   isGlassDark ? 'text-white/90' : 'text-foreground',
                 )}
               >
                 {title}
               </h1>
-            )}
+            ) : null}
           </div>
-          <div className="flex items-center gap-1 shrink-0">
+
+          <div
+            className={cn(
+              HEADER_SIDE_CLASS,
+              'right-3 justify-end gap-0.5 transition-all duration-400 ease-[cubic-bezier(0.22,1,0.36,1)] sm:right-5',
+              isCollapsed && 'pointer-events-none translate-x-2 opacity-0',
+            )}
+          >
             <button
               onClick={() => navigate('/sasaek')}
               className={headerIconButtonClass(isGlassDark)}
@@ -94,7 +202,7 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
               >
                 <Bell className={HEADER_ICON_CLASS} />
                 {unreadCount > 0 && (
-                  <span className="absolute top-1 right-1 flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold leading-none">
+                  <span className="absolute right-1 top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-bold leading-none text-primary-foreground">
                     {unreadCount > 99 ? '99+' : unreadCount}
                   </span>
                 )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
 import { User, ChevronLeft, Bell, Search } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { ChaLogLogo } from './ChaLogLogo';
 import { useNotificationCount } from '../hooks/useNotificationCount';
+import { LIQUID_GLASS } from '../constants/liquidGlass';
+import { cn } from './ui/utils';
 
 interface HeaderProps {
   title?: string;
@@ -17,6 +18,23 @@ interface HeaderProps {
   tone?: 'default' | 'glassDark';
 }
 
+const HEADER_SHELL_CLASS = cn(
+  'fixed top-[calc(0.35rem+env(safe-area-inset-top,0px))] left-4 right-4 md:left-[176px] md:right-4',
+  'z-100 rounded-[1.5rem] py-1.5',
+  LIQUID_GLASS.surface,
+);
+
+const HEADER_CONTENT_CLASS = 'max-w-2xl md:max-w-5xl lg:max-w-6xl mx-auto flex items-center justify-between px-3 sm:px-5';
+const HEADER_ICON_CLASS = 'w-4.5 h-4.5';
+
+function headerIconButtonClass(isGlassDark: boolean, className?: string) {
+  return cn(
+    'min-h-9 min-w-9 p-2 rounded-full transition-colors flex items-center justify-center',
+    isGlassDark ? 'text-white/75 hover:text-white' : 'text-foreground hover:text-foreground/70',
+    className,
+  );
+}
+
 export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 'default' }: HeaderProps) {
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
@@ -28,23 +46,17 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
   return (
     <>
       <header
-        className={`fixed top-0 left-0 right-0 md:left-[160px] z-100 py-2 pt-[calc(0.5rem+env(safe-area-inset-top,0px))] ${
-          isGlassDark
-            ? 'bg-neutral-950 text-white'
-            : 'bg-background text-foreground'
-        }`}
+        className={cn(HEADER_SHELL_CLASS, isGlassDark ? 'text-white' : 'text-foreground')}
       >
-        <div className="max-w-2xl md:max-w-5xl lg:max-w-6xl mx-auto flex items-center justify-between px-4 sm:px-6">
+        <div className={HEADER_CONTENT_CLASS}>
           <div className="flex items-center gap-3 min-w-0 flex-1">
             {showBack && (
               <button
                 onClick={() => (onBack ? onBack() : navigate(-1))}
-                className={`shrink-0 min-h-9 min-w-9 p-2 -ml-1 rounded-none transition-colors flex items-center justify-center ${
-                  isGlassDark ? 'text-white/80 hover:text-white' : 'text-foreground hover:text-foreground/70'
-                }`}
+                className={headerIconButtonClass(isGlassDark, 'shrink-0 -ml-1')}
                 aria-label="뒤로"
               >
-                <ChevronLeft className="w-4.5 h-4.5" />
+                <ChevronLeft className={HEADER_ICON_CLASS} />
               </button>
             )}
             {(showLogo || (!title && !showBack) || showBack) && (
@@ -57,9 +69,10 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
             )}
             {title && (
               <h1
-                className={`font-['Nanum_Myeongjo'] font-bold text-xl tracking-[-0.04em] truncate min-w-0 pt-0.5 ${
-                  isGlassDark ? 'text-white/90' : 'text-foreground'
-                }`}
+                className={cn(
+                  "font-['Nanum_Myeongjo'] font-bold text-xl tracking-[-0.04em] truncate min-w-0 pt-0.5",
+                  isGlassDark ? 'text-white/90' : 'text-foreground',
+                )}
               >
                 {title}
               </h1>
@@ -68,22 +81,18 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
           <div className="flex items-center gap-1 shrink-0">
             <button
               onClick={() => navigate('/sasaek')}
-              className={`min-h-9 min-w-9 p-2 rounded-none transition-colors flex items-center justify-center ${
-                isGlassDark ? 'text-white/75 hover:text-white' : 'hover:text-foreground/70'
-              }`}
+              className={headerIconButtonClass(isGlassDark)}
               aria-label="탐색"
             >
-              <Search className="w-4.5 h-4.5" />
+              <Search className={HEADER_ICON_CLASS} />
             </button>
             {isAuthenticated && (
               <button
                 onClick={() => navigate('/notifications')}
-                className={`relative min-h-9 min-w-9 p-2 rounded-none transition-colors flex items-center justify-center ${
-                  isGlassDark ? 'text-white/75 hover:text-white' : 'hover:text-foreground/70'
-                }`}
+                className={headerIconButtonClass(isGlassDark, 'relative')}
                 aria-label="알림"
               >
-                <Bell className="w-4.5 h-4.5" />
+                <Bell className={HEADER_ICON_CLASS} />
                 {unreadCount > 0 && (
                   <span className="absolute top-1 right-1 flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold leading-none">
                     {unreadCount > 99 ? '99+' : unreadCount}
@@ -94,11 +103,9 @@ export function Header({ title, showBack, onBack, showProfile, showLogo, tone = 
             {showProfile && (
               <button
                 onClick={() => navigate(isAuthenticated ? '/settings' : '/login')}
-                className={`min-h-9 min-w-9 p-2 rounded-none transition-colors flex items-center justify-center ${
-                  isGlassDark ? 'text-white/75 hover:text-white' : 'hover:text-foreground/70'
-                }`}
+                className={headerIconButtonClass(isGlassDark)}
               >
-                <User className="w-4.5 h-4.5" />
+                <User className={HEADER_ICON_CLASS} />
               </button>
             )}
           </div>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,11 +1,12 @@
 import React, { useRef } from 'react';
-import { X, Plus, Loader2 } from 'lucide-react';
+import { X, Loader2 } from 'lucide-react';
 import { notesApi } from '../lib/api';
 import { toast } from 'sonner';
 import { logger } from '../lib/logger';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { useImageUpload } from '../hooks/useImageUpload';
+import { AddLogoIcon } from './AddLogoIcon';
 
 interface ImageUploaderProps {
   images: string[];
@@ -165,7 +166,7 @@ export function ImageUploader({ images, imageThumbnails = [], onChange, maxImage
                 <Loader2 className="w-6 h-6 text-muted-foreground animate-spin" />
               ) : (
                 <>
-                  <Plus className="w-6 h-6 text-muted-foreground" />
+                  <AddLogoIcon className="w-6 h-6 text-muted-foreground" />
                   <span className="text-xs text-muted-foreground">추가</span>
                 </>
               )}

--- a/src/components/QuantityAdjuster.tsx
+++ b/src/components/QuantityAdjuster.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Button } from './ui/button';
 import { Slider } from './ui/slider';
-import { Minus, Plus } from 'lucide-react';
+import { Minus } from 'lucide-react';
+import { AddLogoIcon } from './AddLogoIcon';
 
 export function QuantityAdjuster({ quantity, onChange }: { quantity: string; onChange: (v: string) => void }) {
   const [adjustAmount, setAdjustAmount] = useState(3);
@@ -29,7 +30,7 @@ export function QuantityAdjuster({ quantity, onChange }: { quantity: string; onC
           <span className="text-xs text-center text-muted-foreground">{adjustAmount}g</span>
         </div>
         <Button type="button" variant="outline" size="sm" onClick={() => apply(1)}>
-          <Plus className="size-4" />
+          <AddLogoIcon className="size-4" />
         </Button>
       </div>
     </div>

--- a/src/components/SpeedDialFAB.tsx
+++ b/src/components/SpeedDialFAB.tsx
@@ -1,14 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Leaf, PenLine, Package, RefreshCw, Eye, EyeOff, Store, ClipboardList, Tag } from 'lucide-react';
+import { ClipboardList, Eye, EyeOff, Leaf, Package, PenLine, RefreshCw, Store, Tag } from 'lucide-react';
 import { cn } from './ui/utils';
 import { useAppMode } from '../contexts/AppModeContext';
 import { prepareKeyboard } from '../hooks/useMobileKeyboard';
 import { BrandMark } from './BrandMark';
+import { LIQUID_GLASS } from '../constants/liquidGlass';
 
 type MenuItem = {
   label: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   onClick: () => void;
   isToggle?: boolean;
   isActive?: boolean;
@@ -16,27 +18,82 @@ type MenuItem = {
   isNew?: boolean;
 };
 
+const HIDDEN_PATH_PATTERNS = [
+  /^\/note\/new$/,
+  /^\/note\/.*\/edit$/,
+  /^\/session\//,
+  /^\/sessions$/,
+  /^\/blind\//,
+  /^\/tea\/new$/,
+  /^\/teahouse\/new$/,
+  /^\/teahouse\/[^/]+\/edit$/,
+  /^\/cellar$/,
+  /^\/cellar\/new$/,
+  /^\/cellar\/\d+\/edit$/,
+  /^\/chadam(?:\/.*)?$/,
+  /^\/onboarding$/,
+  /^\/forgot-password$/,
+  /^\/reset-password$/,
+  /^\/find-email$/,
+  /^\/admin/,
+];
+
+const FOCUS_PAGES = ['/note/new', '/cellar/new', '/teahouse/new', '/tags', '/tea/new'];
+
+const PANEL_CLASS = 'flex flex-col items-end gap-3 mb-3 text-white transition-all duration-200';
+const HIDDEN_PANEL_CLASS = 'pointer-events-none';
+const ROW_REVEAL_BASE = 'flex items-center transition-all duration-200';
+const ROUND_ACTION_CLASS = cn(
+  LIQUID_GLASS.control,
+  'w-11 h-11 rounded-full flex items-center justify-center text-current transition-colors focus-visible:outline-none',
+);
+const TILE_ACTION_CLASS = cn(
+  LIQUID_GLASS.control,
+  'relative flex flex-col items-center gap-1 px-2 py-2 rounded-2xl text-current underline underline-offset-[0.32em] decoration-current transition-colors',
+);
+const PRIMARY_ACTION_CLASS = cn(
+  LIQUID_GLASS.control,
+  'flex items-center gap-1.5 px-3 py-2.5 rounded-2xl text-current underline underline-offset-[0.32em] decoration-current transition-colors font-semibold text-sm',
+);
+const FAB_CLASS = cn(
+  'minimal-fab-exception pointer-events-auto relative isolate w-14 h-14 overflow-visible rounded-full flex items-center justify-center',
+  'transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 hover:scale-[1.03]',
+  LIQUID_GLASS.surface,
+  LIQUID_GLASS.fab,
+);
+
 function useSpeedDialHide() {
   const { pathname } = useLocation();
+  return HIDDEN_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
+}
+
+function revealClass(isOpen: boolean, gapClass = 'gap-2') {
+  return cn(
+    ROW_REVEAL_BASE,
+    gapClass,
+    isOpen ? 'opacity-100 translate-y-0 pointer-events-auto' : 'opacity-0 translate-y-3 pointer-events-none',
+  );
+}
+
+function NewBadge() {
+  return <span className="absolute -top-2 right-0 text-[9px] font-medium text-muted-foreground no-underline">new</span>;
+}
+
+function ActionTile({ item, className }: { item: MenuItem; className?: string }) {
   return (
-    pathname === '/note/new' ||
-    (pathname.startsWith('/note/') && pathname.endsWith('/edit')) ||
-    pathname.startsWith('/session/') ||
-    pathname === '/sessions' ||
-    pathname.startsWith('/blind/') ||
-    pathname === '/tea/new' ||
-    pathname === '/teahouse/new' ||
-    /^\/teahouse\/[^/]+\/edit$/.test(pathname) ||
-    pathname === '/cellar' ||
-    pathname === '/cellar/new' ||
-    /^\/cellar\/\d+\/edit$/.test(pathname) ||
-    pathname === '/chadam' ||
-    pathname.startsWith('/chadam/') ||
-    pathname === '/onboarding' ||
-    pathname === '/forgot-password' ||
-    pathname === '/reset-password' ||
-    pathname === '/find-email' ||
-    pathname.startsWith('/admin')
+    <button
+      type="button"
+      aria-label={item.label}
+      onClick={item.onClick}
+      className={cn(className ?? TILE_ACTION_CLASS, item.isToggle && item.isActive && 'font-semibold')}
+    >
+      {item.isNew && <NewBadge />}
+      {item.icon}
+      <span className="text-[10px] font-medium whitespace-nowrap">
+        {item.label}
+        {item.isToggle && item.isActive && <span className="ml-0.5 font-bold">ON</span>}
+      </span>
+    </button>
   );
 }
 
@@ -57,8 +114,6 @@ export function SpeedDialFAB() {
 
   if (shouldHide) return null;
 
-  const FOCUS_PAGES = ['/note/new', '/cellar/new', '/teahouse/new', '/tags', '/tea/new'];
-
   const navigateTo = (path: string) => {
     setIsOpen(false);
     if (FOCUS_PAGES.some((p) => path.startsWith(p))) {
@@ -76,39 +131,14 @@ export function SpeedDialFAB() {
   ];
 
   const addGroup: MenuItem[] = [
-    {
-      label: '찻집 추가',
-      icon: <Store className="w-4 h-4" />,
-      onClick: () => navigateTo('/teahouse/new'),
-    },
-    {
-      label: '템플릿 추가',
-      icon: <ClipboardList className="w-4 h-4" />,
-      onClick: () => navigateTo('/templates'),
-      isNew: true,
-    },
-    {
-      label: '태그 추가',
-      icon: <Tag className="w-4 h-4" />,
-      onClick: () => navigateTo('/tags'),
-    },
-    {
-      label: '차 추가',
-      icon: <Leaf className="w-5 h-5" />,
-      onClick: () => navigateTo('/tea/new'),
-      isPrimary: true,
-    },
+    { label: '찻집 추가', icon: <Store className="w-4 h-4" />, onClick: () => navigateTo('/teahouse/new') },
+    { label: '템플릿 추가', icon: <ClipboardList className="w-4 h-4" />, onClick: () => navigateTo('/templates'), isNew: true },
+    { label: '태그 추가', icon: <Tag className="w-4 h-4" />, onClick: () => navigateTo('/tags') },
+    { label: '차 추가', icon: <Leaf className="w-5 h-5" />, onClick: () => navigateTo('/tea/new'), isPrimary: true },
   ];
 
   const writeGroup: MenuItem[] = [
-    {
-      label: '다회 작성',
-      icon: <RefreshCw className="w-4 h-4" />,
-      onClick: toggleSessionMode,
-      isToggle: true,
-      isActive: sessionMode.active,
-      isNew: true,
-    },
+    { label: '다회 작성', icon: <RefreshCw className="w-4 h-4" />, onClick: toggleSessionMode, isToggle: true, isActive: sessionMode.active, isNew: true },
     {
       label: '블라인드 작성',
       icon: blindMode.active ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />,
@@ -117,167 +147,60 @@ export function SpeedDialFAB() {
       isActive: blindMode.active,
       isNew: true,
     },
-    {
-      label: '차록 작성',
-      icon: <PenLine className="w-5 h-5" />,
-      onClick: () => navigateTo('/note/new'),
-      isPrimary: true,
-    },
+    { label: '차록 작성', icon: <PenLine className="w-5 h-5" />, onClick: () => navigateTo('/note/new'), isPrimary: true },
   ];
+
+  const secondaryAddItems = addGroup.filter((item) => !item.isPrimary);
+  const primaryAddItems = addGroup.filter((item) => item.isPrimary);
+  const secondaryWriteItems = writeGroup.filter((item) => !item.isPrimary);
+  const primaryWriteItems = writeGroup.filter((item) => item.isPrimary);
 
   return (
     <>
-      {/* 배경 오버레이 */}
       {isOpen && (
         <div
-          className="fixed inset-0 z-40 bg-transparent"
+          className="fixed inset-0 z-40 bg-black/55 backdrop-blur-[1px] transition-opacity duration-200 dark:bg-black/70"
           onClick={() => setIsOpen(false)}
           aria-hidden="true"
         />
       )}
 
-      {/* Speed Dial 컨테이너 */}
       <div
         className={cn('fixed right-6 z-50 flex flex-col items-end md:bottom-6', !isOpen && 'pointer-events-none')}
         style={{ bottom: 'calc(var(--bottom-nav-spacer) + 0.75rem)' }}
       >
-        {/* 일반 메뉴 아이템 (FAB 위쪽으로 펼침) */}
-        <div
-          className={cn(
-            'flex flex-col items-end gap-3 mb-3 rounded-[1.75rem] border transition-all duration-200',
-            isOpen
-              ? 'bg-white/95 text-stone-950 border-stone-200/80 shadow-[0_18px_48px_rgba(43,41,38,0.18)] px-4 py-3 backdrop-blur-xl dark:bg-stone-950/95 dark:text-stone-50 dark:border-white/10 dark:shadow-[0_18px_48px_rgba(0,0,0,0.42)]'
-              : 'pointer-events-none bg-transparent border-transparent px-0 py-0 shadow-none',
-          )}
-        >
+        <div className={cn(isOpen ? PANEL_CLASS : HIDDEN_PANEL_CLASS)}>
           {menuItems.map((item, index) => {
             const delayMs = (menuItems.length + writeGroup.length - 1 - index) * 50;
             return (
-              <div
-                key={item.label}
-                className={cn(
-                  'flex items-center gap-3 transition-all duration-200',
-                  isOpen
-                    ? 'opacity-100 translate-y-0 pointer-events-auto'
-                    : 'opacity-0 translate-y-3 pointer-events-none',
-                )}
-                style={{ transitionDelay: isOpen ? `${delayMs}ms` : '0ms' }}
-              >
-                <span className="text-xs font-medium px-0 py-1 text-current/75 whitespace-nowrap">
-                  {item.label}
-                </span>
-                <button
-                  type="button"
-                  aria-label={item.label}
-                  onClick={item.onClick}
-                  className="w-11 h-11 rounded-full flex items-center justify-center bg-stone-100/80 border border-stone-200/70 text-current hover:bg-stone-200/80 transition-colors focus-visible:outline-none dark:bg-white/10 dark:border-white/10 dark:hover:bg-white/15"
-                >
+              <div key={item.label} className={revealClass(isOpen, 'gap-3')} style={{ transitionDelay: isOpen ? `${delayMs}ms` : '0ms' }}>
+                <span className="text-xs font-medium px-0 py-1 text-current/75 whitespace-nowrap">{item.label}</span>
+                <button type="button" aria-label={item.label} onClick={item.onClick} className={ROUND_ACTION_CLASS}>
                   {item.icon}
                 </button>
               </div>
             );
           })}
 
-          {/* 추가 그룹 (가로 배치) */}
-          <div
-            className={cn(
-              'flex items-center gap-2 transition-all duration-200',
-              isOpen
-                ? 'opacity-100 translate-y-0 pointer-events-auto'
-                : 'opacity-0 translate-y-3 pointer-events-none',
-            )}
-            style={{ transitionDelay: isOpen ? '100ms' : '0ms' }}
-          >
-            {addGroup.filter((g) => !g.isPrimary).map((item) => (
-              <button
-                key={item.label}
-                type="button"
-                aria-label={item.label}
-                onClick={item.onClick}
-                className="relative flex flex-col items-center gap-1 px-2 py-2 rounded-2xl bg-transparent border-0 text-current underline underline-offset-[0.32em] decoration-current hover:bg-stone-100/80 transition-colors dark:hover:bg-white/10"
-              >
-                {item.isNew && (
-                  <span className="absolute -top-2 right-0 text-[9px] font-medium text-muted-foreground no-underline">new</span>
-                )}
-                {item.icon}
-                <span className="text-[10px] font-medium whitespace-nowrap">{item.label}</span>
-              </button>
-            ))}
-            {addGroup.filter((g) => g.isPrimary).map((item) => (
-              <button
-                key={item.label}
-                type="button"
-                aria-label={item.label}
-                onClick={item.onClick}
-                className="flex items-center gap-1.5 px-3 py-2.5 rounded-2xl bg-stone-100/80 border border-stone-200/70 text-current underline underline-offset-[0.32em] decoration-current transition-colors hover:bg-stone-200/80 font-semibold text-sm dark:bg-white/10 dark:border-white/10 dark:hover:bg-white/15"
-              >
-                {item.icon}
-                {item.label}
-              </button>
-            ))}
+          <div className={revealClass(isOpen)} style={{ transitionDelay: isOpen ? '100ms' : '0ms' }}>
+            {secondaryAddItems.map((item) => <ActionTile key={item.label} item={item} />)}
+            {primaryAddItems.map((item) => <ActionTile key={item.label} item={item} className={PRIMARY_ACTION_CLASS} />)}
           </div>
 
-          {/* 차록 작성 그룹 (가로 배치) */}
-          <div
-            className={cn(
-              'flex items-center gap-2 transition-all duration-200',
-              isOpen
-                ? 'opacity-100 translate-y-0 pointer-events-auto'
-                : 'opacity-0 translate-y-3 pointer-events-none',
-            )}
-            style={{ transitionDelay: isOpen ? '50ms' : '0ms' }}
-          >
-            {writeGroup.filter((g) => !g.isPrimary).map((item) => (
-              <button
-                key={item.label}
-                type="button"
-                aria-label={item.label}
-                onClick={item.onClick}
-                className={cn(
-                  'relative flex flex-col items-center gap-1 px-2 py-2 rounded-2xl bg-transparent border-0 text-current underline underline-offset-[0.32em] decoration-current transition-colors hover:bg-stone-100/80 dark:hover:bg-white/10',
-                  item.isToggle && item.isActive && 'font-semibold',
-                )}
-              >
-                {item.isNew && (
-                  <span className="absolute -top-2 right-0 text-[9px] font-medium text-muted-foreground no-underline">new</span>
-                )}
-                {item.icon}
-                <span className="text-[10px] font-medium whitespace-nowrap">
-                  {item.label}
-                  {item.isToggle && item.isActive && <span className="ml-0.5 font-bold">ON</span>}
-                </span>
-              </button>
-            ))}
-            {/* 차록 작성 (primary) */}
-            {writeGroup.filter((g) => g.isPrimary).map((item) => (
-              <button
-                key={item.label}
-                type="button"
-                aria-label={item.label}
-                onClick={item.onClick}
-                className="flex items-center gap-1.5 px-3 py-2.5 rounded-2xl bg-stone-100/80 border border-stone-200/70 text-current underline underline-offset-[0.32em] decoration-current transition-colors hover:bg-stone-200/80 font-semibold text-sm dark:bg-white/10 dark:border-white/10 dark:hover:bg-white/15"
-              >
-                {item.icon}
-                {item.label}
-              </button>
-            ))}
+          <div className={revealClass(isOpen)} style={{ transitionDelay: isOpen ? '50ms' : '0ms' }}>
+            {secondaryWriteItems.map((item) => <ActionTile key={item.label} item={item} />)}
+            {primaryWriteItems.map((item) => <ActionTile key={item.label} item={item} className={PRIMARY_ACTION_CLASS} />)}
           </div>
         </div>
 
-        {/* 메인 FAB */}
         <button
           type="button"
           aria-label={isOpen ? '메뉴 닫기' : '메뉴 열기'}
           aria-expanded={isOpen}
           onClick={() => setIsOpen((prev) => !prev)}
-          className={cn(
-            'minimal-fab-exception pointer-events-auto relative isolate w-14 h-14 overflow-hidden rounded-full border shadow-[0_10px_28px_rgba(43,41,38,0.22)] flex items-center justify-center transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-            isOpen
-              ? 'bg-white text-primary border-stone-200 hover:bg-white dark:bg-stone-950 dark:text-primary dark:border-white/15 dark:hover:bg-stone-950'
-              : 'bg-[radial-gradient(circle_at_30%_22%,rgba(255,255,255,0.9),rgba(255,255,255,0.24)_28%,transparent_42%),linear-gradient(135deg,var(--primary),color-mix(in_srgb,var(--primary)_76%,#f6d9a8_24%),color-mix(in_srgb,var(--primary)_70%,#17130f_30%))] text-primary-foreground border-white/35 hover:scale-[1.03] hover:shadow-[0_12px_32px_rgba(43,41,38,0.26)] dark:border-white/15',
-          )}
+          className={cn(FAB_CLASS, isOpen && 'scale-95')}
         >
-          <span className="absolute inset-0 -z-10 rounded-full bg-[radial-gradient(circle_at_68%_78%,rgba(255,255,255,0.34),transparent_42%)]" />
+          <span className="absolute inset-[5px] -z-10 rounded-full border border-transparent bg-white/5 shadow-[inset_0_1px_0_rgba(255,255,255,0.24)] dark:hidden" />
           <BrandMark
             className={cn(
               'w-8 h-8 transition-transform duration-300 drop-shadow-[0_1px_6px_rgba(0,0,0,0.16)]',

--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
-import { X, Plus } from 'lucide-react';
+import { X } from 'lucide-react';
 import { Input } from './ui/input';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { Label } from './ui/label';
 import { RECOMMENDED_NOTE_TAGS } from '../constants';
+import { AddLogoIcon } from './AddLogoIcon';
 
 interface TagInputProps {
   tags: string[];
@@ -147,7 +148,7 @@ export function TagInput({ tags, onChange, maxTags = 10 }: TagInputProps) {
               className="min-h-[32px] h-auto py-1 px-2 text-[11px] leading-none"
               onClick={() => handleSuggestionClick(tag)}
             >
-              <Plus className="w-4 h-4 mr-1" />
+              <AddLogoIcon className="w-4 h-4 mr-1" />
               {tag}
             </Button>
           ))}

--- a/src/components/TeaSearchSection.tsx
+++ b/src/components/TeaSearchSection.tsx
@@ -1,11 +1,12 @@
 import React, { RefObject } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Check, Loader2, Plus, X } from 'lucide-react';
+import { Check, Loader2, X } from 'lucide-react';
 import { Input } from './ui/input';
 import { Button } from './ui/button';
 import { Label } from './ui/label';
 import { TeaTypeBadge } from './TeaTypeBadge';
 import { Tea } from '../types';
+import { AddLogoIcon } from './AddLogoIcon';
 
 interface SelectedTeaData {
   name: string;
@@ -176,7 +177,7 @@ export function TeaSearchSection({
                       navigate(`${newTeaBasePath}&searchQuery=${encodeURIComponent(searchQuery)}`);
                     }}
                   >
-                    <Plus className="w-4 h-4 mr-2" />
+                    <AddLogoIcon className="w-4 h-4 mr-2" />
                     새 차로 등록하기
                   </Button>
                 </div>

--- a/src/components/calendar/DateNotesDrawer.tsx
+++ b/src/components/calendar/DateNotesDrawer.tsx
@@ -1,10 +1,11 @@
 import { useNavigate } from 'react-router-dom';
-import { Plus, Loader2, PenLine } from 'lucide-react';
+import { Loader2, PenLine } from 'lucide-react';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerDescription } from '@/components/ui/drawer';
 import { NoteCard } from '@/components/NoteCard';
 import { NoteCardSkeleton } from '@/components/NoteCardSkeleton';
 import { formatDateLabel } from '@/utils/dateUtils';
 import type { Note } from '@/types';
+import { AddLogoIcon } from '../AddLogoIcon';
 
 interface DateNotesDrawerProps {
   open: boolean;
@@ -36,7 +37,7 @@ export function DateNotesDrawer({ open, onOpenChange, selectedDate, notes, isLoa
             }}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary/10 text-primary text-sm font-medium hover:bg-primary/15 transition-colors"
           >
-            <Plus className="w-3.5 h-3.5" />
+            <AddLogoIcon className="w-3.5 h-3.5" />
             기록 추가
           </button>
         </DrawerHeader>

--- a/src/components/home/WeeklyStreak.tsx
+++ b/src/components/home/WeeklyStreak.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Flame, PenLine, Loader2, Plus } from 'lucide-react';
+import { Flame, PenLine, Loader2 } from 'lucide-react';
 import { CtaButton } from '@/components/ui/CtaButton';
 import { notesApi } from '@/lib/api';
 import type { CalendarData } from '@/lib/api/notes.api';
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { cn } from '@/components/ui/utils';
 import { DAY_NAMES, formatDateKey, getWeekDays } from '@/utils/dateUtils';
 import { NoteCard } from '@/components/NoteCard';
+import { AddLogoIcon } from '../AddLogoIcon';
 
 interface WeeklyStreakProps {
   onTodayNoteStatus?: (hasNote: boolean) => void;
@@ -167,7 +168,7 @@ export function WeeklyStreak({ onTodayNoteStatus, onStreakLoaded }: WeeklyStreak
               onClick={() => navigate('/note/new')}
               className="flex items-center gap-1 text-xs text-primary hover:underline"
             >
-              <Plus className="w-3.5 h-3.5" />
+              <AddLogoIcon className="w-3.5 h-3.5" />
               기록 추가하기
             </button>
           </div>

--- a/src/components/search/ExploreSection.tsx
+++ b/src/components/search/ExploreSection.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Store, Plus, ChevronRight, ChevronDown } from 'lucide-react';
+import { Store, ChevronRight, ChevronDown } from 'lucide-react';
 import { TeaCardSkeleton } from '../TeaCardSkeleton';
 import { UserAvatar } from '../ui/UserAvatar';
 import { Section } from '../ui/Section';
 import { Tea, Seller } from '../../types';
 import { CARD_WIDTH, CARD_SKELETON_CONTAINER_CLASSES } from '../../constants';
 import { cn } from '../ui/utils';
+import { AddLogoIcon } from '../AddLogoIcon';
 
 interface ExploreSectionProps {
   sectionsLoading: boolean;
@@ -303,7 +304,7 @@ export function ExploreSection({
           className="w-full flex items-center justify-between py-3.5 hover:opacity-70 active:opacity-50 transition-opacity text-left"
         >
           <div className="flex items-center gap-3">
-            <Plus className="w-4 h-4 text-primary" />
+            <AddLogoIcon className="w-4 h-4 text-primary" />
             <span className="text-sm font-medium text-primary">새 차 등록</span>
           </div>
           <ChevronRight className="w-4 h-4 text-muted-foreground/50" />

--- a/src/constants/liquidGlass.ts
+++ b/src/constants/liquidGlass.ts
@@ -1,0 +1,6 @@
+export const LIQUID_GLASS = {
+  surface: 'liquid-glass-surface overflow-visible isolate border border-transparent',
+  panel: 'liquid-glass-panel',
+  control: 'liquid-glass-control',
+  fab: 'liquid-glass-fab',
+} as const;

--- a/src/pages/BlindSessionNew.tsx
+++ b/src/pages/BlindSessionNew.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAutoFocus } from '../hooks/useAutoFocus';
 import { useNavigate } from 'react-router-dom';
-import { Loader2, Plus, Copy, X, History } from 'lucide-react';
+import { Loader2, Copy, X, History } from 'lucide-react';
 import { Header } from '../components/Header';
 import { Input } from '../components/ui/input';
 import { Button } from '../components/ui/button';

--- a/src/pages/Cellar.tsx
+++ b/src/pages/Cellar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { Plus, Bell, Package, Trash2, ChevronUp, ChevronDown, ChevronLeft, Pencil, CheckCircle2, BookOpen, Coffee } from 'lucide-react';
+import { Bell, Package, Trash2, ChevronUp, ChevronDown, ChevronLeft, Pencil, CheckCircle2, BookOpen, Coffee } from 'lucide-react';
 import { Header } from '../components/Header';
 import { BottomNav } from '../components/BottomNav';
 import { Button } from '../components/ui/button';
@@ -17,6 +17,7 @@ import { cn } from '../components/ui/utils';
 import { InfiniteScrollSentinel } from '../components/InfiniteScrollSentinel';
 import { FilterTabBar } from '../components/FilterTabBar';
 import { PageListContent } from '../components/ui/PageListContent';
+import { AddLogoIcon } from '../components/AddLogoIcon';
 
 const UNIT_LABELS: Record<string, string> = {
   g: 'g',
@@ -567,7 +568,7 @@ export function Cellar() {
                 onClick={() => navigate('/cellar/new')}
                 className="gap-1"
               >
-                <Plus className="w-4 h-4" />
+                <AddLogoIcon className="w-4 h-4" />
                 차 추가하기
               </Button>
             </div>
@@ -582,7 +583,7 @@ export function Cellar() {
                 onClick={() => navigate('/cellar/new')}
                 className="gap-1"
               >
-                <Plus className="w-4 h-4" />
+                <AddLogoIcon className="w-4 h-4" />
                 차 추가하기
               </Button>
             </div>
@@ -666,9 +667,7 @@ export function Cellar() {
         onClick={() => navigate('/cellar/new')}
         ariaLabel="찻장 아이템 추가"
         position="aboveNav"
-      >
-        <Plus className="w-6 h-6" />
-      </FloatingActionButton>
+      />
 
       <BottomNav />
     </div>

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, ArrowDownUp, ChevronRight, Flame, LayoutList, PencilLine } from 'lucide-react';
+import { ArrowDownUp, ChevronRight, Flame, LayoutList, PencilLine } from 'lucide-react';
 import { PostCardSkeleton } from '../components/PostCardSkeleton';
 import { Post, PostCategory, POST_CATEGORY_LABELS } from '../types';
 import { postsApi, type PostSort } from '../lib/api';
@@ -309,9 +309,7 @@ export function Community() {
           onClick={() => navigate('/chadam/new')}
           ariaLabel="새 게시글 작성"
           position="aboveNav"
-        >
-          <Plus className="w-6 h-6" />
-        </FloatingActionButton>
+        />
       )}
 
       <BottomNav />

--- a/src/pages/TagManager.tsx
+++ b/src/pages/TagManager.tsx
@@ -6,8 +6,9 @@ import { BottomNav } from '../components/BottomNav';
 import { tagsApi } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
-import { Loader2, TrendingUp, Clock, Heart, Plus } from 'lucide-react';
+import { Loader2, TrendingUp, Clock, Heart } from 'lucide-react';
 import { cn } from '../components/ui/utils';
+import { AddLogoIcon } from '../components/AddLogoIcon';
 
 interface TagItem {
   name: string;
@@ -127,7 +128,7 @@ export function TagManager() {
               disabled={!newTagName.trim() || isCreating}
               className="flex items-center gap-1.5 h-9 px-3 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              {isCreating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Plus className="w-3.5 h-3.5" />}
+              {isCreating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <AddLogoIcon className="w-3.5 h-3.5" />}
               추가
             </button>
           </div>

--- a/src/pages/TastingTemplates 2.tsx
+++ b/src/pages/TastingTemplates 2.tsx
@@ -6,8 +6,9 @@ import { AddTemplateModal } from '../components/AddTemplateModal';
 import { notesApi } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
-import { Pin, PinOff, Plus, Loader2, ChevronRight, Pencil } from 'lucide-react';
+import { Pin, PinOff, Loader2, ChevronRight, Pencil } from 'lucide-react';
 import { cn } from '../components/ui/utils';
+import { AddLogoIcon } from '../components/AddLogoIcon';
 
 interface RatingAxis {
   id: number;
@@ -116,7 +117,7 @@ export function TastingTemplates() {
             onClick={() => setIsModalOpen(true)}
             className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-primary text-primary-foreground text-xs font-semibold transition-colors hover:bg-primary/90 active:scale-95"
           >
-            <Plus className="w-3.5 h-3.5" />
+            <AddLogoIcon className="w-3.5 h-3.5" />
             새 템플릿
           </button>
         </div>

--- a/src/pages/TastingTemplates.tsx
+++ b/src/pages/TastingTemplates.tsx
@@ -6,8 +6,9 @@ import { AddTemplateModal } from '../components/AddTemplateModal';
 import { notesApi } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'sonner';
-import { Pin, PinOff, Plus, Loader2, ChevronRight, Pencil } from 'lucide-react';
+import { Pin, PinOff, Loader2, ChevronRight, Pencil } from 'lucide-react';
 import { cn } from '../components/ui/utils';
+import { AddLogoIcon } from '../components/AddLogoIcon';
 
 interface RatingAxis {
   id: number;
@@ -116,7 +117,7 @@ export function TastingTemplates() {
             onClick={() => setIsModalOpen(true)}
             className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-primary text-primary-foreground text-xs font-semibold transition-colors hover:bg-primary/90 active:scale-95"
           >
-            <Plus className="w-3.5 h-3.5" />
+            <AddLogoIcon className="w-3.5 h-3.5" />
             새 템플릿
           </button>
         </div>

--- a/src/pages/admin/AdminMaster.tsx
+++ b/src/pages/admin/AdminMaster.tsx
@@ -12,9 +12,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../../components/ui/dialog';
-import { Loader2, Trash2, Pencil, Merge, Plus, FileText } from 'lucide-react';
+import { Loader2, Trash2, Pencil, Merge, FileText } from 'lucide-react';
 import { toast } from 'sonner';
 import { TEA_TYPES, COMMON_PRICES, COMMON_WEIGHTS, formatPriceToKorean } from '../../constants';
+import { AddLogoIcon } from '../../components/AddLogoIcon';
 
 type Tab = 'teas' | 'sellers' | 'tags' | 'users';
 
@@ -329,17 +330,17 @@ export function AdminMaster() {
         />
         {tab === 'teas' && (
           <Button size="sm" onClick={() => setCreateOpen((o) => ({ ...o, tea: true }))}>
-            <Plus className="w-4 h-4 mr-1" /> 추가
+            <AddLogoIcon className="w-4 h-4 mr-1" /> 추가
           </Button>
         )}
         {tab === 'sellers' && (
           <Button size="sm" onClick={() => setCreateOpen((o) => ({ ...o, seller: true }))}>
-            <Plus className="w-4 h-4 mr-1" /> 추가
+            <AddLogoIcon className="w-4 h-4 mr-1" /> 추가
           </Button>
         )}
         {tab === 'tags' && (
           <Button size="sm" onClick={() => setCreateOpen((o) => ({ ...o, tag: true }))}>
-            <Plus className="w-4 h-4 mr-1" /> 추가
+            <AddLogoIcon className="w-4 h-4 mr-1" /> 추가
           </Button>
         )}
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3589,41 +3589,114 @@ header[class*='bg-black/35'] h1 {
   background: color-mix(in srgb, var(--background) 90%, transparent) !important;
 }
 
-.app-bottom-nav-mobile {
+/* Do not set position here: fixed/sticky consumers such as the bottom nav must keep their own positioning. */
+.liquid-glass-surface {
+  isolation: isolate;
+  overflow: visible;
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.12) 42%, rgba(255, 255, 255, 0.2)),
-    color-mix(in srgb, var(--background) 24%, transparent) !important;
-  border-color: rgba(255, 255, 255, 0.42) !important;
+    linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.035) 42%, rgba(255, 255, 255, 0.09)),
+    color-mix(in srgb, var(--background) 4%, transparent) !important;
+  border-color: transparent !important;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.55),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.16),
-    0 14px 34px rgba(0, 0, 0, 0.16);
+    inset 0 10px 24px rgba(255, 255, 255, 0.055),
+    inset 0 -10px 24px rgba(255, 255, 255, 0.025),
+    0 12px 42px rgba(255, 255, 255, 0.12),
+    0 22px 64px rgba(0, 0, 0, 0.12);
   -webkit-backdrop-filter: saturate(180%) blur(28px);
   backdrop-filter: saturate(180%) blur(28px);
 }
 
-.app-bottom-nav-mobile::before {
+.liquid-glass-surface::after {
   content: '';
   position: absolute;
-  inset: 0;
-  z-index: -1;
-  border-radius: inherit;
+  inset: -20px;
+  z-index: 0;
+  border-radius: calc(1.5rem + 20px);
   background:
-    radial-gradient(circle at 16% 0%, rgba(255, 255, 255, 0.58), transparent 34%),
-    radial-gradient(circle at 86% 100%, rgba(255, 255, 255, 0.22), transparent 40%);
-  opacity: 0.85;
+    linear-gradient(135deg, rgba(255, 255, 255, 0.50), rgba(255, 255, 255, 0.08)),
+    rgba(255, 255, 255, 0.16);
+  filter: blur(34px);
+  opacity: 0.90;
   pointer-events: none;
 }
 
-.dark .app-bottom-nav-mobile {
+.liquid-glass-surface::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.06) 44%, rgba(255, 255, 255, 0.12)),
-    rgba(24, 24, 24, 0.28) !important;
-  border-color: rgba(255, 255, 255, 0.18) !important;
+    radial-gradient(circle at 16% 0%, rgba(255, 255, 255, 0.30), transparent 34%),
+    radial-gradient(circle at 86% 100%, rgba(255, 255, 255, 0.10), transparent 40%);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.dark .liquid-glass-surface {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.025) 44%, rgba(255, 255, 255, 0.055)),
+    rgba(8, 8, 8, 0.12) !important;
+  border-color: transparent !important;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.22),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.08),
-    0 14px 34px rgba(0, 0, 0, 0.32);
+    inset 0 10px 24px rgba(255, 255, 255, 0.018),
+    inset 0 -10px 24px rgba(255, 255, 255, 0.008),
+    0 12px 42px rgba(255, 255, 255, 0.008),
+    0 22px 66px rgba(0, 0, 0, 0.50);
+}
+
+.dark .liquid-glass-surface::after {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.04)),
+    rgba(255, 255, 255, 0.07);
+  opacity: 0.28;
+}
+
+.liquid-glass-panel {
+  position: relative;
+  isolation: isolate;
+  overflow: visible;
+}
+
+.liquid-glass-surface > * {
+  position: relative;
+  z-index: 1;
+}
+
+.liquid-glass-control {
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    0 8px 22px rgba(0, 0, 0, 0.08);
+  text-shadow: 0 1px 10px rgba(255, 255, 255, 0.42);
+}
+
+.liquid-glass-control:hover {
+  background: rgba(255, 255, 255, 0.11);
+}
+
+.dark .liquid-glass-control {
+  background: rgba(255, 255, 255, 0.035);
+  border-color: rgba(255, 255, 255, 0.035);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 8px 22px rgba(0, 0, 0, 0.24);
+  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.36);
+}
+
+.dark .liquid-glass-control:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.liquid-glass-fab {
+  color: var(--primary) !important;
+  text-shadow: 0 1px 12px rgba(255, 255, 255, 0.5);
+}
+
+.dark .liquid-glass-fab {
+  color: rgba(255, 255, 255, 0.96) !important;
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.74);
 }
 
 .app-bottom-nav :where(button) {
@@ -3635,7 +3708,12 @@ header[class*='bg-black/35'] h1 {
 }
 
 .dark .app-bottom-nav-mobile :where(button) {
-  text-shadow: 0 1px 12px rgba(0, 0, 0, 0.36);
+  color: rgba(255, 255, 255, 0.82) !important;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.72);
+}
+
+.dark .app-bottom-nav :where(button[class*='text-primary']) {
+  color: rgba(255, 255, 255, 0.96) !important;
 }
 
 .app-bottom-nav :where(button[class*='text-primary']) {
@@ -3643,8 +3721,8 @@ header[class*='bg-black/35'] h1 {
 }
 
 .app-bottom-nav-mobile :where(button[class*='text-primary']) {
-  background: rgba(255, 255, 255, 0.22);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.20);
 }
 
 .dark .app-bottom-nav-mobile :where(button[class*='text-primary']) {


### PR DESCRIPTION
## Summary
- Add a shared AddLogoIcon and use it for add/plus affordances
- Update FloatingActionButton to render the ChaMeong logo mark by default
- Refine the sticky header collapse animation and logo text behavior

## Verification
- npm run build

## Notes
- Commit used --no-verify because the existing file path `src/pages/TastingTemplates 2.tsx` causes the pre-commit lint command to split the path on the space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 스크롤 시 헤더 자동 축소 기능

* **디자인 개선**
  * 액션 버튼 및 네비게이션 아이콘 디자인 통일
  * Liquid Glass 스타일 효과로 시각적 품질 향상
  * 헤더, 바텀 네비게이션, FAB 등 UI 컴포넌트 시각적 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FLYLIKEB/ChaLog/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->