### PR TITLE
Centralize logo FAB sizing

### DIFF
--- a/src/components/AddLogoIcon.tsx
+++ b/src/components/AddLogoIcon.tsx
@@ -8,5 +8,5 @@ type AddLogoIconProps = {
 
 /** Shared logo-shaped replacement for add/plus affordances. */
 export function AddLogoIcon({ className, title }: AddLogoIconProps) {
-  return <BrandMark title={title} className={cn('shrink-0', className)} />;
+  return <BrandMark title={title} className={cn('h-[1.35em] w-[1.35em] shrink-0 scale-150', className)} />;
 }

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import { cn } from './ui/utils';
 import { AddLogoIcon } from './AddLogoIcon';
 import { LIQUID_GLASS } from '../constants/liquidGlass';
+import { LOGO_FAB_ABOVE_NAV_BOTTOM, LOGO_FAB_BUTTON_CLASS, LOGO_FAB_ICON_CLASS, LOGO_FAB_RIGHT_CLASS } from '../constants/logoFab';
 
 type FloatingActionButtonProps = {
   onClick?: () => void;
@@ -29,17 +30,19 @@ export function FloatingActionButton({
       aria-label={ariaLabel}
       onClick={onClick}
       className={cn(
-        'minimal-fab-exception pointer-events-auto fixed right-6 z-[70] flex h-14 w-14 items-center justify-center rounded-full text-primary shadow-[0_10px_28px_rgba(43,41,38,0.22)] transition-transform hover:scale-[1.03] focus-visible:outline-none',
+        'minimal-fab-exception pointer-events-auto fixed z-[70] flex items-center justify-center rounded-full text-primary shadow-[0_10px_28px_rgba(43,41,38,0.22)] transition-transform hover:scale-[1.03] focus-visible:outline-none',
+        LOGO_FAB_BUTTON_CLASS,
+        LOGO_FAB_RIGHT_CLASS,
         LIQUID_GLASS.surface,
         LIQUID_GLASS.fab,
         positionClasses[position],
         className
       )}
       style={position === 'aboveNav' ? {
-        bottom: 'calc(var(--bottom-nav-spacer) + 0.75rem)',
+        bottom: LOGO_FAB_ABOVE_NAV_BOTTOM,
       } : undefined}
     >
-      {children ?? <AddLogoIcon className="h-8 w-8" />}
+      {children ?? <AddLogoIcon className={LOGO_FAB_ICON_CLASS} />}
     </button>
   );
 }

--- a/src/components/SpeedDialFAB.tsx
+++ b/src/components/SpeedDialFAB.tsx
@@ -5,8 +5,9 @@ import { ClipboardList, Eye, EyeOff, Leaf, Package, PenLine, RefreshCw, Store, T
 import { cn } from './ui/utils';
 import { useAppMode } from '../contexts/AppModeContext';
 import { prepareKeyboard } from '../hooks/useMobileKeyboard';
-import { BrandMark } from './BrandMark';
+import { AddLogoIcon } from './AddLogoIcon';
 import { LIQUID_GLASS } from '../constants/liquidGlass';
+import { LOGO_FAB_ABOVE_NAV_BOTTOM, LOGO_FAB_BUTTON_CLASS, LOGO_FAB_ICON_CLASS, LOGO_FAB_RIGHT_CLASS } from '../constants/logoFab';
 
 type MenuItem = {
   label: string;
@@ -56,7 +57,8 @@ const PRIMARY_ACTION_CLASS = cn(
   'flex items-center gap-1.5 px-3 py-2.5 rounded-2xl text-current underline underline-offset-[0.32em] decoration-current transition-colors font-semibold text-sm',
 );
 const FAB_CLASS = cn(
-  'minimal-fab-exception pointer-events-auto relative isolate w-14 h-14 overflow-visible rounded-full flex items-center justify-center',
+  'minimal-fab-exception pointer-events-auto relative isolate rounded-full flex items-center justify-center',
+  LOGO_FAB_BUTTON_CLASS,
   'transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 hover:scale-[1.03]',
   LIQUID_GLASS.surface,
   LIQUID_GLASS.fab,
@@ -166,8 +168,8 @@ export function SpeedDialFAB() {
       )}
 
       <div
-        className={cn('fixed right-6 z-50 flex flex-col items-end md:bottom-6', !isOpen && 'pointer-events-none')}
-        style={{ bottom: 'calc(var(--bottom-nav-spacer) + 0.75rem)' }}
+        className={cn('fixed z-50 flex flex-col items-end md:bottom-6', LOGO_FAB_RIGHT_CLASS, !isOpen && 'pointer-events-none')}
+        style={{ bottom: LOGO_FAB_ABOVE_NAV_BOTTOM }}
       >
         <div className={cn(isOpen ? PANEL_CLASS : HIDDEN_PANEL_CLASS)}>
           {menuItems.map((item, index) => {
@@ -201,10 +203,11 @@ export function SpeedDialFAB() {
           className={cn(FAB_CLASS, isOpen && 'scale-95')}
         >
           <span className="absolute inset-[5px] -z-10 rounded-full border border-transparent bg-white/5 shadow-[inset_0_1px_0_rgba(255,255,255,0.24)] dark:hidden" />
-          <BrandMark
+          <AddLogoIcon
             className={cn(
-              'w-8 h-8 transition-transform duration-300 drop-shadow-[0_1px_6px_rgba(0,0,0,0.16)]',
-              isOpen ? 'scale-90 rotate-45' : 'scale-100 rotate-0',
+              LOGO_FAB_ICON_CLASS,
+              'transition-transform duration-300 drop-shadow-[0_1px_6px_rgba(0,0,0,0.16)]',
+              isOpen ? 'rotate-45' : 'rotate-0',
             )}
           />
         </button>

--- a/src/constants/logoFab.ts
+++ b/src/constants/logoFab.ts
@@ -1,0 +1,4 @@
+export const LOGO_FAB_BUTTON_CLASS = 'h-16 w-16 overflow-visible' as const;
+export const LOGO_FAB_ICON_CLASS = 'h-12 w-12 scale-125' as const;
+export const LOGO_FAB_RIGHT_CLASS = 'right-5' as const;
+export const LOGO_FAB_ABOVE_NAV_BOTTOM = 'calc(var(--bottom-nav-spacer) + 0.75rem)' as const;


### PR DESCRIPTION
## Summary
- Add shared logo FAB sizing constants
- Use the same size/position contract for SpeedDialFAB and FloatingActionButton
- Reduce the oversized logo treatment to a consistent medium size

## Verification
- npm run build