### PR TITLE
Refine Chadam typography and post spacing

### DIFF
--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -172,7 +172,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
                         onChange={(e) => setEditContent(e.target.value)}
                         rows={2}
                         autoFocus
-                        className="min-h-0 text-sm"
+                        className="post-detail-comment-editor min-h-0 text-sm"
                       />
                       <div className="flex gap-2">
                         <Button
@@ -196,7 +196,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
                       </div>
                     </div>
                   ) : (
-                    <p className="text-sm text-foreground leading-relaxed mt-0.5">
+                    <p className="post-detail-comment-content text-sm text-foreground leading-relaxed mt-0.5">
                       {comment.content}
                     </p>
                   )}
@@ -232,7 +232,7 @@ export function CommentList({ postId, comments, onCommentsChange }: CommentListP
               onChange={(e) => setNewContent(e.target.value)}
               placeholder="댓글을 입력하세요..."
               maxLength={1000}
-              className="flex-1 h-10 bg-transparent border-0 text-sm text-foreground placeholder:text-muted-foreground/40 focus:outline-none caret-primary"
+              className="post-detail-comment-input flex-1 h-10 bg-transparent border-0 text-sm text-foreground placeholder:text-muted-foreground/40 focus:outline-none caret-primary"
             />
             {/* 전송 버튼 */}
             <button

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -32,7 +32,7 @@ const PostCardComponent: FC<PostCardProps> = ({ post, commentCount }) => {
     return (
       <div
         onClick={handleClick}
-        className="px-4 py-2.5 bg-muted/40 rounded-lg cursor-pointer active:bg-muted/60 transition-colors flex items-center gap-2"
+        className="px-4 py-3.5 bg-muted/40 rounded-lg cursor-pointer active:bg-muted/60 transition-colors flex items-center gap-2"
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
@@ -43,7 +43,7 @@ const PostCardComponent: FC<PostCardProps> = ({ post, commentCount }) => {
         }}
       >
         <Pin className="w-4 h-4 text-green-600 shrink-0" />
-        <span className="flex-1 min-w-0 text-sm font-medium text-foreground truncate">{post.title || post.content}</span>
+        <span className={cn('flex-1 min-w-0 text-sm font-medium text-foreground truncate', !post.title && 'post-card-content-preview')}>{post.title || post.content}</span>
         <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
       </div>
     );
@@ -52,7 +52,7 @@ const PostCardComponent: FC<PostCardProps> = ({ post, commentCount }) => {
   return (
     <div
       onClick={handleClick}
-      className="px-5 py-4 cursor-pointer active:bg-muted/20 transition-colors"
+      className="px-5 py-5 cursor-pointer active:bg-muted/20 transition-colors"
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
@@ -115,7 +115,7 @@ const PostCardComponent: FC<PostCardProps> = ({ post, commentCount }) => {
               {post.title}
             </h3>
           )}
-          <p className="text-[14px] text-foreground/80 line-clamp-2 leading-relaxed">
+          <p className="post-card-content-preview text-[14px] text-foreground/80 line-clamp-2 leading-relaxed">
             {post.content}
           </p>
         </div>

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -225,7 +225,7 @@ export function Community() {
                   action={{ label: '✍️ 첫 글 쓰기', onClick: () => navigate('/chadam/new') }}
                 />
               ) : (
-                <div className="space-y-1">
+                <div className="space-y-3">
                   {posts.map((post, i) => (
                     <div key={post.id} className="animate-fade-in-up opacity-0" style={{ animationDelay: `${Math.min(i, 5) * 50}ms` }}>
                       <PostCard post={post} />
@@ -263,7 +263,7 @@ export function Community() {
                         {boardPosts.length === 0 ? (
                           <p className="text-sm text-muted-foreground py-4 text-center">아직 게시글이 없어요.</p>
                         ) : (
-                          <div className="space-y-1">
+                          <div className="space-y-3">
                             {boardPosts.map((post, i) => (
                               <div key={post.id} className="animate-fade-in-up opacity-0" style={{ animationDelay: `${i * 50}ms` }}>
                                 <PostCard post={post} />
@@ -277,7 +277,7 @@ export function Community() {
                 </div>
               ) : (
                 <>
-                  <div className="space-y-1">
+                  <div className="space-y-3">
                     {posts.map((post, i) => (
                       <div key={post.id} className="animate-fade-in-up opacity-0" style={{ animationDelay: `${Math.min(i, 5) * 50}ms` }}>
                         <PostCard post={post} />

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -253,11 +253,11 @@ export function PostDetail() {
 
         {/* 제목 */}
         {post.title && (
-          <h1 className="post-detail-title text-lg font-bold text-foreground leading-snug mb-3">{post.title}</h1>
+          <h1 className="post-detail-title font-['Nanum_Myeongjo'] text-lg font-bold leading-snug tracking-[-0.04em] text-foreground mb-3">{post.title}</h1>
         )}
 
         {/* 본문 */}
-        <div className="space-y-3">
+        <div className="post-detail-body space-y-3">
           <div className="post-detail-content text-[15px] text-foreground leading-relaxed whitespace-pre-wrap [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:mt-3 [&_h2]:mb-1.5 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-2 [&_h3]:mb-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:my-2 [&_li]:my-0.5 [&_code]:bg-muted [&_code]:px-1 [&_code]:rounded [&_code]:text-sm [&_pre]:bg-muted [&_pre]:p-3 [&_pre]:rounded-lg [&_pre]:overflow-x-auto [&_pre]:my-2 [&_a]:text-primary [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-muted-foreground/30 [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:my-2 [&_table]:w-full [&_table]:border-collapse [&_table]:my-3 [&_th]:border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-sm [&_th]:font-medium [&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-2 [&_td]:text-sm">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{post.content}</ReactMarkdown>
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3963,6 +3963,60 @@ header[class*='bg-black/35'] h1 {
     sans-serif !important;
 }
 
+/* Chadam post detail: use the brand serif for page chrome, but keep article body/comments readable. */
+.post-detail-page :where(
+  header,
+  header *,
+  .post-detail-paper > :not(.post-detail-body),
+  .post-detail-paper > :not(.post-detail-body) *,
+  .post-detail-reading-dock,
+  .post-detail-reading-dock *
+) {
+  font-family: 'Nanum Myeongjo', 'Apple SD Gothic Neo', serif !important;
+}
+
+.post-detail-page .post-detail-title {
+  font-family: 'Nanum Myeongjo', 'Apple SD Gothic Neo', serif !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.04em !important;
+}
+
+.post-detail-page :where(
+  .post-detail-comments,
+  .post-detail-comments *
+) {
+  font-family: 'Nanum Myeongjo', 'Apple SD Gothic Neo', serif !important;
+}
+
+.post-detail-page :where(
+  .post-detail-body,
+  .post-detail-body *,
+  .post-detail-comment-content,
+  .post-detail-comment-content *,
+  .post-detail-comment-editor,
+  .post-detail-comment-editor *,
+  .post-detail-comment-input
+) {
+  font-family:
+    'Pretendard',
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    sans-serif !important;
+}
+
+
+/* Chadam list: keep visible post body previews in Pretendard for readability. */
+.post-card-content-preview,
+.post-card-content-preview * {
+  font-family:
+    'Pretendard',
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    sans-serif !important;
+}
+
 /* Chadam post detail: Brunch-like reading surface. */
 .post-detail-page {
   background: #fff;


### PR DESCRIPTION
## Summary
- apply Nanum Myeongjo to Chadam detail UI chrome while preserving Pretendard for body/comment text
- keep Chadam list body previews in Pretendard
- increase vertical spacing between Chadam post cards

## Test
- npm run build
- pre-commit lint